### PR TITLE
Client-Side Preview

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 		   "type": "coreclr",
 		   "request": "launch",
 		   "preLaunchTask": "build_forumengine",
-		   "program": "${workspaceRoot}/TASVideos.ForumEngineTempTest/bin/Debug/netcoreapp2.1/TASVideos.ForumEngineTempTest.dll",
+		   "program": "${workspaceRoot}/TASVideos.ForumEngineTempTest/bin/Debug/netcoreapp2.2/TASVideos.ForumEngineTempTest.dll",
 		   "args": [],
 		   "cwd": "${workspaceRoot}",
 		   "stopAtEntry": false,
@@ -21,7 +21,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/TASVideos/bin/Debug/netcoreapp2.1/TASVideos.dll",
+            "program": "${workspaceFolder}/TASVideos/bin/Debug/netcoreapp2.2/TASVideos.dll",
             "args": [],
             "cwd": "${workspaceFolder}/TASVideos",
             "stopAtEntry": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.insertSpaces": false,
+    "editor.detectIndentation": false
+}

--- a/TASVideos.WikiEngine/Escape.cs
+++ b/TASVideos.WikiEngine/Escape.cs
@@ -25,5 +25,31 @@ namespace TASVideos.WikiEngine
 
 			w.Write('"');
 		}
+		public static void WriteJsString(TextWriter w, string s)
+		{
+			w.Write('"');
+			foreach (var c in s)
+			{
+				if (c < 0x20)
+				{
+					w.Write($"\\x{(int)c:x2}");
+				}
+				else if (c == '"')
+				{
+					w.Write("\\\"");
+				}
+				else if (c == '/')
+				{
+					// avoid </script> inside string
+					w.Write("\\/");
+				}
+				else
+				{
+					w.Write(c);
+				}
+			}
+
+			w.Write('"');
+		}
 	}
 }

--- a/TASVideos.WikiEngine/Node.cs
+++ b/TASVideos.WikiEngine/Node.cs
@@ -261,6 +261,7 @@ namespace TASVideos.WikiEngine.AST
 
 	public class IfModule : INodeWithChildren
 	{
+		private static int AjaxModuleId = 0;
 		public NodeType Type => NodeType.IfModule;
 		public List<INode> Children { get; private set; } = new List<INode>();
 		public string Condition { get; }
@@ -290,7 +291,17 @@ namespace TASVideos.WikiEngine.AST
 		}
 		public void WriteHtml(TextWriter w)
 		{
-			w.Write("TODO: IFMODULE");
+			var ajaxmoduleid = Interlocked.Increment(ref AjaxModuleId).ToString();
+			w.Write($"<span class=hiddenifmodule data-ajaxmoduleid=\"{ajaxmoduleid}\">");
+			w.Write($"<script>");
+			w.Write("ajaxIfModuleHelper(");
+			Escape.WriteJsString(w, Condition);
+			w.Write(',');
+			Escape.WriteJsString(w, ajaxmoduleid);
+			w.Write(")</script>");
+			foreach (var c in Children)
+				c.WriteHtml(w);
+			w.Write("</span>");
 		}
 
 		public INode Clone()

--- a/TASVideos.WikiEngine/Node.cs
+++ b/TASVideos.WikiEngine/Node.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-
+using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -24,6 +24,7 @@ namespace TASVideos.WikiEngine.AST
 		int CharStart { get; }
 		int CharEnd { get; set; }
 		void WriteRazor(TextWriter w);
+		void WriteHtml(TextWriter w);
 		INode Clone();
 	}
 
@@ -64,6 +65,25 @@ namespace TASVideos.WikiEngine.AST
 						break;
 				}
 			}
+		}
+
+		public void WriteHtml(TextWriter w)
+		{
+			foreach (var c in Content)
+			{
+				switch (c)
+				{
+					case '<':
+						w.Write("&lt;");
+						break;
+					case '&':
+						w.Write("&amp;");
+						break;
+					default:
+						w.Write(c);
+						break;
+				}
+			}			
 		}
 
 		public INode Clone()
@@ -175,6 +195,61 @@ namespace TASVideos.WikiEngine.AST
 			}
 		}
 
+		public void WriteHtml(TextWriter w)
+		{
+			if (VoidTags.Contains(Tag) && Children.Count > 0)
+			{
+				throw new InvalidOperationException("Void tag with child content!");
+			}
+
+			w.Write('<');
+			w.Write(Tag);
+			foreach (var a in Attributes)
+			{
+				if (!AllowedAttributeNames.IsMatch(a.Key))
+				{
+					throw new InvalidOperationException("Invalid attribute name");
+				}
+				w.Write(' ');
+				w.Write(a.Key);
+				w.Write("=\"");
+				foreach (var c in a.Value)
+				{
+					switch (c)
+					{
+						case '<':
+							w.Write("&lt;");
+							break;
+						case '&':
+							w.Write("&amp;");
+							break;
+						case '"':
+							w.Write("&quot;");
+							break;
+						default:
+							w.Write(c);
+							break;
+					}
+				}
+
+				w.Write('"');
+			}
+
+			if (VoidTags.Contains(Tag))
+			{
+				w.Write(" />");
+			}
+			else
+			{
+				w.Write('>');
+				foreach (var c in Children)
+					c.WriteHtml(w);
+				w.Write("</");
+				w.Write(Tag);
+				w.Write('>');
+			}
+		}
+
 		public INode Clone()
 		{
 			var ret = (Element)MemberwiseClone();
@@ -213,6 +288,10 @@ namespace TASVideos.WikiEngine.AST
 				c.WriteRazor(w);
 			w.Write("</text>}");
 		}
+		public void WriteHtml(TextWriter w)
+		{
+			w.Write("TODO: IFMODULE");
+		}
 
 		public INode Clone()
 		{
@@ -224,6 +303,7 @@ namespace TASVideos.WikiEngine.AST
 
 	public class Module : INode
 	{
+		private static int AjaxModuleId = 0;
 		private static readonly Dictionary<string, string> ModuleNameMaps = new Dictionary<string, string>
 		{
 			["listsubpages"] = "ListSubPages",
@@ -279,6 +359,32 @@ namespace TASVideos.WikiEngine.AST
 				div.Children.Add(new Text(CharStart, "Unknown module " + moduleName) { CharEnd = CharEnd });
 				div.Attributes["class"] = "module-error";
 				div.WriteRazor(w);
+			}
+		}
+
+		public void WriteHtml(TextWriter w)
+		{
+			var pp = Text.Split(new[] { '|' }, 2);
+			var moduleName = pp[0];
+			var moduleParams = pp.Length > 1 ? pp[1] : "";
+			if (ModuleNameMaps.TryGetValue(moduleName?.ToLower(), out string realModuleName))
+			{
+				var ajaxmoduleid = Interlocked.Increment(ref AjaxModuleId).ToString();
+				w.Write($"<script data-ajaxmoduleid=\"{ajaxmoduleid}\">");
+				w.Write("ajaxModuleHelper(");
+				Escape.WriteJsString(w, realModuleName);
+				w.Write(',');
+				Escape.WriteJsString(w, moduleParams);
+				w.Write(',');
+				Escape.WriteJsString(w, ajaxmoduleid);
+				w.Write(")</script>");
+			}
+			else
+			{
+				var div = new Element(CharStart, "div") { CharEnd = CharEnd };
+				div.Children.Add(new Text(CharStart, "Unknown module " + moduleName) { CharEnd = CharEnd });
+				div.Attributes["class"] = "module-error";
+				div.WriteHtml(w);
 			}
 		}
 

--- a/TASVideos.WikiEngine/Util.cs
+++ b/TASVideos.WikiEngine/Util.cs
@@ -45,6 +45,15 @@ namespace TASVideos.WikiEngine
 				r.WriteRazor(w);
 			}
 		}
+		public static void RenderHtml(string content, TextWriter w)
+		{
+			var results = NewParser.Parse(content);
+
+			foreach (var r in results)
+			{
+				r.WriteHtml(w);
+			}
+		}
 
 		public static IEnumerable<NewParser.WikiLinkInfo> GetAllWikiLinks(string content)
 		{

--- a/TASVideos/Extensions/ApplicationBuilderExtensions.cs
+++ b/TASVideos/Extensions/ApplicationBuilderExtensions.cs
@@ -40,7 +40,7 @@ namespace TASVideos.Extensions
 			// public only when user is logged out, else no-cache
 			// Which is precisely the behavior we want
 			app.UseResponseCaching();
-			app.Use(async (context, next) =>
+			/*app.Use(async (context, next) =>
 			{
 				context.Response.GetTypedHeaders().CacheControl =
 					new Microsoft.Net.Http.Headers.CacheControlHeaderValue
@@ -52,7 +52,7 @@ namespace TASVideos.Extensions
 					new[] { "Accept-Encoding" };
 
 				await next();
-			});
+			});*/
 
 			app.UseMvc();
 

--- a/TASVideos/Pages/Shared/_PreviewWindow.cshtml
+++ b/TASVideos/Pages/Shared/_PreviewWindow.cshtml
@@ -19,7 +19,7 @@
 			xmlhttp.onreadystatechange = function() {
 				if (xmlhttp.readyState === XMLHttpRequest.DONE) {
 					if (xmlhttp.status === 200) {
-						document.getElementById('preview-contents').innerHTML = xmlhttp.responseText;
+						$(document.getElementById('preview-contents')).empty().append($(xmlhttp.responseText));
 					} else {
 						alert("Could not generate preview");
 					}

--- a/TASVideos/Pages/Wiki/DoIfModule.cshtml
+++ b/TASVideos/Pages/Wiki/DoIfModule.cshtml
@@ -1,0 +1,11 @@
+@page
+@model DoIfModuleModel
+@{ Layout = null; }
+@if(Html.WikiCondition(Model.Condition))
+{
+    <text>true</text>
+}
+else
+{
+    <text>false</text>
+}

--- a/TASVideos/Pages/Wiki/DoIfModule.cshtml.cs
+++ b/TASVideos/Pages/Wiki/DoIfModule.cshtml.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TASVideos.Tasks;
+
+namespace TASVideos.Pages.Wiki
+{
+    [AllowAnonymous]
+    public class DoIfModuleModel : BasePageModel
+    {
+        public DoIfModuleModel(UserTasks userTasks)
+                : base(userTasks)
+        {
+        }
+
+        [FromQuery]
+        public string Condition { get; set; }
+    }
+}

--- a/TASVideos/Pages/Wiki/DoModule.cshtml
+++ b/TASVideos/Pages/Wiki/DoModule.cshtml
@@ -1,3 +1,4 @@
 @page
 @model DoModuleModel
-@(await Component.InvokeAsync(Model.Name, new { pageData = null, pp = Model.Params }))
+@{ Layout = null; }
+@(await Component.InvokeAsync(Model.Name, new { pageData = (WikiPage)null, pp = Model.Params }))

--- a/TASVideos/Pages/Wiki/DoModule.cshtml
+++ b/TASVideos/Pages/Wiki/DoModule.cshtml
@@ -1,0 +1,3 @@
+@page
+@model DoModuleModel
+@(await Component.InvokeAsync(Model.Name, new { pageData = null, pp = Model.Params }))

--- a/TASVideos/Pages/Wiki/DoModule.cshtml.cs
+++ b/TASVideos/Pages/Wiki/DoModule.cshtml.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TASVideos.Tasks;
+
+namespace TASVideos.Pages.Wiki
+{
+    [AllowAnonymous]
+    public class DoModuleModel : BasePageModel
+    {
+        public DoModuleModel(UserTasks userTasks)
+                : base(userTasks)
+        {
+        }
+
+        [FromQuery]
+        public string Name { get; set; }
+
+        [FromQuery]
+        public string Params { get; set; }
+    }
+}

--- a/TASVideos/Pages/Wiki/Preview.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Preview.cshtml.cs
@@ -28,17 +28,12 @@ namespace TASVideos.Pages.Wiki
 
 		public string Html { get; set; } = "";
 
-		public void OnPost()
+		public IActionResult OnPost()
 		{
 			var input = new StreamReader(Request.Body, Encoding.UTF8).ReadToEnd();
-
-			// ViewData["WikiPage"] = null;
-			// ViewData["Title"] = "Generated Preview";
-			// ViewData["Layout"] = null;
-
-			var tw = new StreamWriter(Response.Body, Encoding.UTF8);
-			Response.ContentType = "text/plain"; // really HTML, yeah
-			Util.RenderHtml(input, tw);
+			var sw = new StringWriter();
+			Util.RenderHtml(input, sw);
+			return Content(sw.ToString(), "text/plain"); // really HTML, yeah
 		}
 	}
 }

--- a/TASVideos/Pages/Wiki/Preview.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Preview.cshtml.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using TASVideos.Models;
 using TASVideos.Razor;
 using TASVideos.Tasks;
+using TASVideos.WikiEngine;
 
 namespace TASVideos.Pages.Wiki
 {
@@ -25,16 +26,20 @@ namespace TASVideos.Pages.Wiki
 			_wikiMarkupFileProvider = wikiMarkupFileProvider;
 		}
 
+		public string Html { get; set; } = "";
+
 		public IActionResult OnPost()
 		{
 			var input = new StreamReader(Request.Body, Encoding.UTF8).ReadToEnd();
 
-			ViewData["WikiPage"] = null;
-			ViewData["Title"] = "Generated Preview";
-			ViewData["Layout"] = null;
-			var name = _wikiMarkupFileProvider.SetPreviewMarkup(input);
+			// ViewData["WikiPage"] = null;
+			// ViewData["Title"] = "Generated Preview";
+			// ViewData["Layout"] = null;
 
-			return Partial(name);
+			var sw = new StringWriter(); // TODO: is there a better way to do this without StringWriter, like, by streaming to the page or something?
+			Util.RenderHtml(input, sw);
+			Html = sw.ToString();
+			return Page();
 		}
 	}
 }

--- a/TASVideos/Pages/Wiki/Preview.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Preview.cshtml.cs
@@ -28,7 +28,7 @@ namespace TASVideos.Pages.Wiki
 
 		public string Html { get; set; } = "";
 
-		public IActionResult OnPost()
+		public void OnPost()
 		{
 			var input = new StreamReader(Request.Body, Encoding.UTF8).ReadToEnd();
 
@@ -36,10 +36,9 @@ namespace TASVideos.Pages.Wiki
 			// ViewData["Title"] = "Generated Preview";
 			// ViewData["Layout"] = null;
 
-			var sw = new StringWriter(); // TODO: is there a better way to do this without StringWriter, like, by streaming to the page or something?
-			Util.RenderHtml(input, sw);
-			Html = sw.ToString();
-			return Page();
+			var tw = new StreamWriter(Response.Body, Encoding.UTF8);
+			Response.ContentType = "text/plain"; // really HTML, yeah
+			Util.RenderHtml(input, tw);
 		}
 	}
 }

--- a/TASVideos/Pages/Wiki/Preview.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Preview.cshtml.cs
@@ -33,7 +33,7 @@ namespace TASVideos.Pages.Wiki
 			var input = new StreamReader(Request.Body, Encoding.UTF8).ReadToEnd();
 			var sw = new StringWriter();
 			Util.RenderHtml(input, sw);
-			return Content(sw.ToString(), "text/plain"); // really HTML, yeah
+			return Content(sw.ToString(), "text/plain"); // really HTML, but a fragment so `text/plain` is good enough
 		}
 	}
 }

--- a/TASVideos/wwwroot/css/site.css
+++ b/TASVideos/wwwroot/css/site.css
@@ -104,3 +104,7 @@ h1 {
 [data-toggle="collapse"].collapsed .fa::before {
 	content: "\f13a";
 }
+
+.hiddenifmodule {
+	display: none;
+}

--- a/TASVideos/wwwroot/js/site.js
+++ b/TASVideos/wwwroot/js/site.js
@@ -87,3 +87,10 @@
 NodeList.prototype.toArray = function () {
 	return Array.prototype.slice.call(this);
 };
+
+// does this go here?
+function ajaxModuleHelper(name, params, elementId) {
+	var $element = $("script[data-ajaxmoduleid=" + elementId + "]");
+	// send a get to DoModule?Name={name}&Params={params}
+	// get the HTML back, and then replace $element with it
+}

--- a/TASVideos/wwwroot/js/site.js
+++ b/TASVideos/wwwroot/js/site.js
@@ -91,6 +91,13 @@ NodeList.prototype.toArray = function () {
 // does this go here?
 function ajaxModuleHelper(name, params, elementId) {
 	var $element = $("script[data-ajaxmoduleid=" + elementId + "]");
-	// send a get to DoModule?Name={name}&Params={params}
-	// get the HTML back, and then replace $element with it
+	var x = new XMLHttpRequest();
+	x.onreadystatechange = function() {
+		if (x.readyState === XMLHttpRequest.DONE && x.status === 200) {
+			$element.replaceWith($(x.responseText));
+		}
+	};
+
+	x.open("GET", "/Wiki/DoModule?Name=" + encodeURIComponent(name) + "&Params=" + encodeURIComponent(params), true);
+	x.send();
 }


### PR DESCRIPTION
Adds a new WriteHtml method to WikiNodes that outputs pure HTML for them, and uses that for preview functionality.  Modules and Ifs are supported through AJAX.

Avoids expensive razor compiles for ephemeral content