### PR TITLE
TagHelper injection prevention

### DIFF
--- a/TASVideos/TagHelpers/BootstrapTagHelpers.cs
+++ b/TASVideos/TagHelpers/BootstrapTagHelpers.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using static TASVideos.TagHelpers.TagHelperExtensions;
 
 namespace TASVideos.TagHelpers
 {
@@ -226,7 +227,7 @@ $@"<button type=""button"" class=""close"" data-dismiss=""alert"" aria-label=""c
 				<button type='button' class='close' data-dismiss='modal'><span aria-hidden='true'>&times;</span></button>
 			</div>
 			<div class='modal-body'>
-				<p>{WarningMessage}</p>
+				<p>{Text(WarningMessage)}</p>
 			</div>
 			<div class='modal-footer'>
 				<form action='{WebUtility.UrlDecode(AspHref)}' method='post'>

--- a/TASVideos/TagHelpers/CardLink.cs
+++ b/TASVideos/TagHelpers/CardLink.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+using static TASVideos.TagHelpers.TagHelperExtensions;
 
 namespace TASVideos.TagHelpers
 {
@@ -20,10 +21,10 @@ namespace TASVideos.TagHelpers
 
 			output.Content.AppendHtml($@"
 	<h4 class='card-link-header'>
-		{Header}
+		{Text(Header)}
 	</h4>
 	<span class='card-link-body'>
-		{Body}
+		{Text(Body)}
 	</span>
 	<span class='card-link-arrow fa fa-chevron-right'></span>
 ");

--- a/TASVideos/TagHelpers/CollapsableTagHelper.cs
+++ b/TASVideos/TagHelpers/CollapsableTagHelper.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using static TASVideos.TagHelpers.TagHelperExtensions;
 
 namespace TASVideos.TagHelpers
 {
@@ -19,14 +20,21 @@ namespace TASVideos.TagHelpers
 
 			// TODO: sr and aria tags could use something more informative than BodyId
 			output.Content.AppendHtml($@"
-<a class='collapsed' data-toggle='collapse' href='#{BodyId}' aria-expanded='false' aria-controls='collapse1' role='button'>
-	{content}
-</a>
-<a data-toggle='collapse' class='collapsed btn btn-default btn-xs text-right' href='#{BodyId}' aria-label='Expand/Collapse {BodyId}' aria-expanded='false' role='button'>
-	<i class='fa' aria-hidden='true'></i>
-	<span class='sr-only'>Expand/Collapse {BodyId}</span>
-</a>
-");
+				<a class='collapsed' data-toggle='collapse' {Attr("href", "#" + BodyId)} aria-expanded='false' aria-controls='collapse1' role='button'>
+					{content}
+				</a>
+				<a
+					data-toggle='collapse'
+					class='collapsed btn btn-default btn-xs text-right'
+					{Attr("href", "#" + BodyId)}
+					{Attr("aria-label", $"Expand/Collapse {BodyId}")}
+					aria-expanded='false'
+					role='button'
+				>
+					<i class='fa' aria-hidden='true'></i>
+					<span class='sr-only'>Expand/Collapse {Text(BodyId)}</span>
+				</a>
+			");
 		}
 	}
 

--- a/TASVideos/TagHelpers/NavbarTagHelpers.cs
+++ b/TASVideos/TagHelpers/NavbarTagHelpers.cs
@@ -53,8 +53,7 @@ namespace TASVideos.TagHelpers
 			}
 
 			output.Content.SetHtmlContent(
-				$"<a href='#' class='nav-link dropdown-toggle' data-toggle='dropdown'>{Text(Name ?? "")}<span class='caret'></span></a>"
-			);
+				$"<a href='#' class='nav-link dropdown-toggle' data-toggle='dropdown'>{Text(Name ?? "")}<span class='caret'></span></a>");
 
 			output.Content.AppendHtml($"<div class='dropdown-menu'>{content}</div>");
 		}

--- a/TASVideos/TagHelpers/NavbarTagHelpers.cs
+++ b/TASVideos/TagHelpers/NavbarTagHelpers.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 using TASVideos.Extensions;
+using static TASVideos.TagHelpers.TagHelperExtensions;
 
 namespace TASVideos.TagHelpers
 {
@@ -52,7 +53,8 @@ namespace TASVideos.TagHelpers
 			}
 
 			output.Content.SetHtmlContent(
-				$"<a href='#' class='nav-link dropdown-toggle' data-toggle='dropdown'>{Name}<span class='caret'></span></a>");
+				$"<a href='#' class='nav-link dropdown-toggle' data-toggle='dropdown'>{Text(Name ?? "")}<span class='caret'></span></a>"
+			);
 
 			output.Content.AppendHtml($"<div class='dropdown-menu'>{content}</div>");
 		}

--- a/TASVideos/TagHelpers/SortableTableHeadTagHelper.cs
+++ b/TASVideos/TagHelpers/SortableTableHeadTagHelper.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 using TASVideos.Data;
 using TASVideos.Extensions;
+using static TASVideos.TagHelpers.TagHelperExtensions;
 
 namespace TASVideos.TagHelpers
 {
@@ -69,7 +70,7 @@ namespace TASVideos.TagHelpers
 					}
 
 					output.Content.AppendHtml(
-						$"<a href='{page}?Sort={sortStr}{AdditionalParams()}'>");
+						$"<a {Attr("href", ComputeHref(sortStr))}>");
 					output.Content.AppendHtml(displayName);
 
 					if (isSort)
@@ -90,6 +91,13 @@ namespace TASVideos.TagHelpers
 
 				output.Content.AppendHtml("</th>");
 			}
+		}
+
+		private string ComputeHref(string sortStr)
+		{
+			// TODO: Probably need some URL escaping in here
+			var page = ViewContext.ActionDescriptor.DisplayName;
+			return $"{page}?Sort={sortStr}{AdditionalParams()}";
 		}
 
 		private string AdditionalParams()

--- a/TASVideos/TagHelpers/StringListTagHelper.cs
+++ b/TASVideos/TagHelpers/StringListTagHelper.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using static TASVideos.TagHelpers.TagHelperExtensions;
 
 namespace TASVideos.TagHelpers
 {
@@ -37,7 +38,7 @@ namespace TASVideos.TagHelpers
 				output.Content.AppendHtml($@"
 <div class='author-row row mb-1' data-index='{i}'>
 	<div class='col-10'>
-		<input type='text' spellcheck='false' class='form-control' id='{modelId}_{i}_' name='{modelName}' value='{stringList[i]}' />
+		<input type='text' spellcheck='false' class='form-control' {Attr("id", $"{modelId}_{i}_")} {Attr("name", modelName)} {Attr("value", stringList[i])} />
 	</div>
 	<div class='col-2'>
 		<button {(i == 0 ? "id='" + modelId + "-add-btn'" : "")} class='string-list-add-btn btn btn-secondary {(i > 0 ? "d-none" : "")}' type='button'><span class='fa fa-plus-square'></span></button>

--- a/TASVideos/TagHelpers/StringListTagHelper.cs
+++ b/TASVideos/TagHelpers/StringListTagHelper.cs
@@ -41,7 +41,7 @@ namespace TASVideos.TagHelpers
 		<input type='text' spellcheck='false' class='form-control' {Attr("id", $"{modelId}_{i}_")} {Attr("name", modelName)} {Attr("value", stringList[i])} />
 	</div>
 	<div class='col-2'>
-		<button {(i == 0 ? "id='" + modelId + "-add-btn'" : "")} class='string-list-add-btn btn btn-secondary {(i > 0 ? "d-none" : "")}' type='button'><span class='fa fa-plus-square'></span></button>
+		<button {(i == 0 ? Attr("id", modelId + "-add-btn") : "")} class='string-list-add-btn btn btn-secondary {(i > 0 ? "d-none" : "")}' type='button'><span class='fa fa-plus-square'></span></button>
 		<button onclick='this.parentElement.parentElement.remove()' class='string-list-remove-btn btn btn-danger {(i == 0 ? "d-none" : "")}' type='button'><span class='fa fa-remove'></span></button>
 	</div>
 </div>");
@@ -50,16 +50,16 @@ namespace TASVideos.TagHelpers
 			var uniqueFuncName = "selectList" + context.UniqueId;
 			output.Content.AppendHtml(
 $@"<script>
-	function {uniqueFuncName}() {{
-		var addBtn = document.getElementById('{modelId}-add-btn');
+	function {JsValue(uniqueFuncName)}() {{
+		var addBtn = document.getElementById({JsValue($"{modelId}-add-btn")});
 		addBtn.onclick = function() {{
-			var lastIndex = Math.max.apply(null, document.querySelectorAll('#{parentContainerName} .author-row')
+			var lastIndex = Math.max.apply(null, document.querySelectorAll({JsValue($"#{parentContainerName} .author-row")})
 				.toArray()
 				.map(function(elem) {{
 					return parseInt(elem.getAttribute('data-index'));
 				}}));
 
-			var lastElem = document.querySelector('#{parentContainerName} [data-index=""' + lastIndex + '""]');
+			var lastElem = document.querySelector({JsValue($@"#{parentContainerName} [data-index=""' + lastIndex + '""]")});
 
 			var newIndex = lastIndex + 1;
 			var newElem = lastElem.cloneNode(true);
@@ -74,10 +74,10 @@ $@"<script>
 			var removeBtn = newElem.querySelector('.string-list-remove-btn');
 			removeBtn.classList.remove('d-none');
 
-			document.querySelector('#{parentContainerName} div[class=""string-list-container""]').appendChild(newElem);
+			document.querySelector({JsValue($@"#{parentContainerName} div[class=""string-list-container""]")}).appendChild(newElem);
 		}}
 	}}
-	{uniqueFuncName}();
+	{JsValue(uniqueFuncName)}();
 </script>
 ");
 			output.Content.AppendHtml("</div>");

--- a/TASVideos/TagHelpers/TagHelperExtensions.cs
+++ b/TASVideos/TagHelpers/TagHelperExtensions.cs
@@ -1,7 +1,9 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Encodings.Web;
-
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
@@ -28,6 +30,37 @@ namespace TASVideos.TagHelpers
 			var writer = new StringWriter();
 			content.WriteTo(writer, HtmlEncoder.Default);
 			return writer.ToString();
+		}
+
+		private static readonly Regex ValidAttributeName = new Regex("^[^\t\n\f \\/>\"'=]$");
+
+		public static string Attr(string name, string value)
+		{
+			if (!ValidAttributeName.IsMatch(name))
+				throw new ArgumentException($"Attribute name `{name}` contains invalid characters", nameof(name));
+			var sb = new StringBuilder(name.Length + value.Length + 3);
+			sb.Append(name);
+			sb.Append("=\"");
+			foreach (var c in name)
+			{
+				switch(c)
+				{
+					case '<':
+						sb.Append("&lt;");
+						break;
+					case '&':
+						sb.Append("&amp;");
+						break;
+					case '"':
+						sb.Append("&quot;");
+						break;
+					default:
+						sb.Append(c);
+						break;
+				}
+			}
+			sb.Append('"');
+			return sb.ToString();
 		}
 	}
 }

--- a/TASVideos/TagHelpers/TagHelperExtensions.cs
+++ b/TASVideos/TagHelpers/TagHelperExtensions.cs
@@ -32,8 +32,11 @@ namespace TASVideos.TagHelpers
 			return writer.ToString();
 		}
 
-		private static readonly Regex ValidAttributeName = new Regex("^[^\t\n\f \\/>\"'=]$");
+		private static readonly Regex ValidAttributeName = new Regex("^[^\t\n\f \\/>\"'=]+$");
 
+		/// <summary>
+		/// Return an HTML attribute <code>name=&quot;value&quot;</code> pair with appropriate escaping.
+		/// </summary>
 		public static string Attr(string name, string value)
 		{
 			if (!ValidAttributeName.IsMatch(name))
@@ -61,6 +64,56 @@ namespace TASVideos.TagHelpers
 			}
 			sb.Append('"');
 			return sb.ToString();
+		}
+
+		/// <summary>
+		/// Returns raw text HTML escaped suitable for use in a regular element body
+		/// </summary>
+		/// <param name="text"></param>
+		/// <returns></returns>
+		public static string Text(string text)
+		{
+			var sb = new StringBuilder(text.Length);
+			foreach (var c in text)
+			{
+				switch(c)
+				{
+					case '<':
+						sb.Append("&lt;");
+						break;
+					case '&':
+						sb.Append("&amp;");
+						break;
+					default:
+						sb.Append(c);
+						break;
+				}
+			}
+			return sb.ToString();
+		}
+
+		// This is overly restrictive.  If you want to name your js identifiers fÖÖbar, feel free to change it.
+		private static readonly Regex ValidJsIdentifier = new Regex("^[a-zA-Z_$][^[a-zA-Z_$0-9]+$");
+
+		/// <summary>
+		/// Returns a JS identifier suitable for use inside a script tag, after verifying that all characters in it are sane
+		/// </summary>
+		public static string JsIdentifier(string identifier)
+		{
+			if (!ValidJsIdentifier.IsMatch(identifier))
+				throw new ArgumentException($"Identifier `{identifier}` contains invalid characters", nameof(identifier));
+			return identifier;
+		}
+
+		/// <summary>
+		/// Returns a value serialized to javascript, suitable for inclusion in a script tag.
+		/// </summary>
+		/// <param name="value"></param>
+		/// <returns></returns>
+		public static string JsValue(object? value)
+		{
+			// Newtonsoft by default never escapes `/`; we always escape it to avoid stray </script>s.
+			return Newtonsoft.Json.JsonConvert.SerializeObject(value).Replace("/", "\\/");
 		}
 	}
 }

--- a/TASVideos/TagHelpers/TagHelperExtensions.cs
+++ b/TASVideos/TagHelpers/TagHelperExtensions.cs
@@ -40,13 +40,16 @@ namespace TASVideos.TagHelpers
 		public static string Attr(string name, string value)
 		{
 			if (!ValidAttributeName.IsMatch(name))
+			{
 				throw new ArgumentException($"Attribute name `{name}` contains invalid characters", nameof(name));
+			}
+
 			var sb = new StringBuilder(name.Length + value.Length + 3);
 			sb.Append(name);
 			sb.Append("=\"");
 			foreach (var c in name)
 			{
-				switch(c)
+				switch (c)
 				{
 					case '<':
 						sb.Append("&lt;");
@@ -62,6 +65,7 @@ namespace TASVideos.TagHelpers
 						break;
 				}
 			}
+
 			sb.Append('"');
 			return sb.ToString();
 		}
@@ -76,7 +80,7 @@ namespace TASVideos.TagHelpers
 			var sb = new StringBuilder(text.Length);
 			foreach (var c in text)
 			{
-				switch(c)
+				switch (c)
 				{
 					case '<':
 						sb.Append("&lt;");
@@ -89,6 +93,7 @@ namespace TASVideos.TagHelpers
 						break;
 				}
 			}
+
 			return sb.ToString();
 		}
 
@@ -101,7 +106,10 @@ namespace TASVideos.TagHelpers
 		public static string JsIdentifier(string identifier)
 		{
 			if (!ValidJsIdentifier.IsMatch(identifier))
+			{
 				throw new ArgumentException($"Identifier `{identifier}` contains invalid characters", nameof(identifier));
+			}
+
 			return identifier;
 		}
 

--- a/TASVideos/TagHelpers/TimeZoneConvert.cs
+++ b/TASVideos/TagHelpers/TimeZoneConvert.cs
@@ -51,7 +51,7 @@ namespace TASVideos.TagHelpers
 				}
 				catch
 				{
-					// TImeZoneInfo throws an exception if it can not find the timezone
+					// TimeZoneInfo throws an exception if it can not find the timezone
 					// Eat the exception and simply don't convert
 				}
 			}
@@ -61,7 +61,7 @@ namespace TASVideos.TagHelpers
 				: dateTime.ToString(CultureInfo.CurrentCulture);
 			output.TagName = "span";
 			output.TagMode = TagMode.StartTagAndEndTag;
-			output.Content.AppendHtml(dateStr);
+			output.Content.AppendHtml(TagHelperExtensions.Text(dateStr));
 		}
 
 		private void ValidateExpression()

--- a/TASVideos/TagHelpers/TimeZonePickerTagHelper.cs
+++ b/TASVideos/TagHelpers/TimeZonePickerTagHelper.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using static TASVideos.TagHelpers.TagHelperExtensions;
 
 namespace TASVideos.TagHelpers
 {
@@ -53,13 +54,17 @@ namespace TASVideos.TagHelpers
 
 			foreach (var optgroup in groups)
 			{
-				output.Content.AppendHtml($"<optgroup label='{optgroup}'>");
+				output.Content.AppendHtml($"<optgroup {Attr("label", optgroup.ToString())}>");
 
 				var options = availableTimezones.Where(t => t.BaseUtcOffset == optgroup);
 
 				foreach (var option in options)
 				{
-					output.Content.AppendHtml($"<option {(option.Selected ? "selected" : "")} value='{option.Id}' data-offset='{option.BaseUtcOffset.TotalMinutes}'>{option.DisplayName}</option>");
+					output.Content.AppendHtml($@"
+						<option {(option.Selected ? "selected" : "")} {Attr("value", option.Id)} {Attr("data-offset", option.BaseUtcOffset.TotalMinutes.ToString())}>
+							{Text(option.DisplayName)}
+						</option>
+					");
 				}
 
 				output.Content.AppendHtml("</optgroup>");

--- a/TASVideos/TagHelpers/TwoColumnSelectTagHelper.cs
+++ b/TASVideos/TagHelpers/TwoColumnSelectTagHelper.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 
 using TASVideos.Data.Entity;
 using TASVideos.Extensions;
+using static TASVideos.TagHelpers.TagHelperExtensions;
 
 namespace TASVideos.TagHelpers
 {
@@ -72,10 +73,10 @@ namespace TASVideos.TagHelpers
 			output.Attributes.Add("id", parentContainerName);
 
 			// Generate hidden form element that will contain the selected ids
-			output.Content.AppendHtml($"<span id='{modelContainer}'>");
+			output.Content.AppendHtml($"<span {Attr("id", modelContainer)}>");
 			foreach (var id in selectedIdList)
 			{
-				output.Content.AppendHtml($"<input type='hidden' v='{id}' name='{IdList.Name}' value='{id}' />");
+				output.Content.AppendHtml($"<input type='hidden' v='{id}' {Attr("name", IdList.Name)} value='{id}' />");
 			}
 
 			output.Content.AppendHtml("</span>");
@@ -90,8 +91,16 @@ namespace TASVideos.TagHelpers
 				AvailableList.ModelExplorer.Metadata.DisplayName,
 				new { @class = "form-control-label" }));
 
-			output.Content.AppendHtml(
-				$"<select class='form-control' id='{availableListName}' multiple='multiple' name='{availableListName}' size='{rowSize}' style='overflow-y: auto; padding-top: 7px;'>");
+			output.Content.AppendHtml($@"
+				<select
+					class='form-control'
+					{Attr("id", availableListName)}
+					multiple='multiple'
+					{Attr("name", availableListName)}
+					size='{rowSize}'
+					style='overflow-y: auto; padding-top: 7px;'
+				>
+			");
 			output.Content.AppendHtml(
 				_htmlGenerator.GenerateGroupsAndOptions(null, remainingItems));
 			output.Content.AppendHtml("</select>");
@@ -99,36 +108,36 @@ namespace TASVideos.TagHelpers
 
 			// Middle Column Div
 			output.Content.AppendHtml($@"
-<div class='col-2'>
-	<div class='row'>
-		<div class='offset-md-3 col-md-6'>
-			<label class='form-control-label'> </label>
-			<div class='row mb-1'>
-				<button type='button' id='{addBtnName}' class='btn btn-primary btn-sm col-12' aria-label='Add' title='Add'>
-					<i class='fa fa-chevron-right' aria-hidden='true'></i>
-				</button>
-			</div>
-			<div class='row mb-4'>
-				<button type='button' id='{addAllBtnName}' class='btn btn-primary btn-sm col-12' aria-label='Add All' title='Add All'>
-					<i class='fa fa-chevron-right' aria-hidden='true'></i>
-					<i class='fa fa-chevron-right' aria-hidden='true'></i>
-				</button>
-			</div>
-			<div class='row mb-1'>
-				<button type='button' id='{removeBtnName}' class='btn btn-primary btn-sm col-12' aria-label='Remove' title='Remove'>
-					<i class='fa fa-chevron-left' aria-hidden='true'></i>
-				</button>
-			</div>
-			<div class='row'>
-				<button type='button' id='{removeAllBtnName}' class='btn btn-primary btn-sm col-12' aria-label='Remove All' title='Remove All'>
-					<i class='fa fa-chevron-left' aria-hidden='true'></i>
-					<i class='fa fa-chevron-left' aria-hidden='true'></i>
-				</button>
-			</div>
-		</div>
-	</div>
-</div>
-");
+				<div class='col-2'>
+					<div class='row'>
+						<div class='offset-md-3 col-md-6'>
+							<label class='form-control-label'> </label>
+							<div class='row mb-1'>
+								<button type='button' {Attr("id", addBtnName)} class='btn btn-primary btn-sm col-12' aria-label='Add' title='Add'>
+									<i class='fa fa-chevron-right' aria-hidden='true'></i>
+								</button>
+							</div>
+							<div class='row mb-4'>
+								<button type='button' {Attr("id", addAllBtnName)} class='btn btn-primary btn-sm col-12' aria-label='Add All' title='Add All'>
+									<i class='fa fa-chevron-right' aria-hidden='true'></i>
+									<i class='fa fa-chevron-right' aria-hidden='true'></i>
+								</button>
+							</div>
+							<div class='row mb-1'>
+								<button type='button' {Attr("id", removeBtnName)} class='btn btn-primary btn-sm col-12' aria-label='Remove' title='Remove'>
+									<i class='fa fa-chevron-left' aria-hidden='true'></i>
+								</button>
+							</div>
+							<div class='row'>
+								<button type='button' {Attr("id", removeAllBtnName)} class='btn btn-primary btn-sm col-12' aria-label='Remove All' title='Remove All'>
+									<i class='fa fa-chevron-left' aria-hidden='true'></i>
+									<i class='fa fa-chevron-left' aria-hidden='true'></i>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			");
 
 			// Right Column Div
 			output.Content.AppendHtml("<div class='col-5'>");
@@ -141,7 +150,7 @@ namespace TASVideos.TagHelpers
 				new { @class = "form-control-label", @for = selectedListName }));
 
 			output.Content.AppendHtml(
-				$"<select class='form-control' id='{selectedListName}' multiple='multiple' size='{rowSize}' style='overflow-y: auto; padding-top: 7px;'>");
+				$"<select class='form-control' {Attr("id", selectedListName)} multiple='multiple' size='{rowSize}' style='overflow-y: auto; padding-top: 7px;'>");
 			output.Content.AppendHtml(
 				_htmlGenerator.GenerateGroupsAndOptions(null, selectedItems));
 			output.Content.AppendHtml("</select>");
@@ -150,87 +159,86 @@ namespace TASVideos.TagHelpers
 				_htmlGenerator.GenerateValidationMessage(ViewContext, IdList.ModelExplorer, IdList.Name, null, null, new { @class = "text-danger" }));
 
 			output.Content.AppendHtml("</div>");
-
 			// Script Tag
 			var uniqueFuncName = "twoColumnPicker" + context.UniqueId;
-			string script = $@"<script>function {uniqueFuncName}() {{
-				var twoColumnChangeEvent = new CustomEvent('{modelName}Changed', {{ bubbles: true }});
+			string script = $@"<script>function {JsIdentifier(uniqueFuncName)}() {{
+				var twoColumnChangeEvent = new CustomEvent({JsValue(modelName + "Change")}, {{ bubbles: true }});
 
-				document.getElementById('{parentContainerName}').listChangedCallback = null;
+				document.getElementById({JsValue(parentContainerName)}).listChangedCallback = null;
 
-				document.getElementById('{availableListName}').addEventListener('dblclick', function() {{
-					document.getElementById('{addBtnName}').click()
+				document.getElementById({JsValue(availableListName)}).addEventListener('dblclick', function() {{
+					document.getElementById({JsValue(addBtnName)}).click()
 				}});
 
-				document.getElementById('{selectedListName}').addEventListener('dblclick', function() {{
-					document.getElementById('{removeBtnName}').click()
+				document.getElementById({JsValue(selectedListName)}).addEventListener('dblclick', function() {{
+					document.getElementById({JsValue(removeBtnName)}).click()
 				}});
 
-				document.getElementById('{addBtnName}').addEventListener('click', function () {{
-					var aopts = document.querySelectorAll('#{availableListName} option:checked');
+				document.getElementById({JsValue(addBtnName)}).addEventListener('click', function () {{
+					var aopts = document.querySelectorAll({JsValue($"#{availableListName} option:checked")});
 					aopts.forEach(function (elem) {{
 						var newInp = document.createElement('input')
-						newInp.name = '{modelName}';
+						newInp.name = {JsValue(modelName)};
 						newInp.type = 'hidden';
 						newInp.value = elem.value;
 						newInp.setAttribute('v', elem.value);
-						document.getElementById('{modelContainer}').appendChild(newInp);
-						document.getElementById('{selectedListName}').appendChild(elem.cloneNode(true));
-						document.getElementById('{availableListName}').removeChild(elem);
+						document.getElementById({JsValue(modelContainer)}).appendChild(newInp);
+						document.getElementById({JsValue(selectedListName)}).appendChild(elem.cloneNode(true));
+						document.getElementById({JsValue(availableListName)}).removeChild(elem);
 					}});
 
 					sortLists();
 
 					if (aopts.length) {{
-						document.getElementById('{parentContainerName}').dispatchEvent(twoColumnChangeEvent);
+						document.getElementById({JsValue(parentContainerName)}).dispatchEvent(twoColumnChangeEvent);
 					}}
 				}});
 
-				document.getElementById('{addAllBtnName}').addEventListener('click', function () {{
-					var aopts = document.querySelectorAll('#{availableListName} option:not(:disabled)');
+				document.getElementById({JsValue(addAllBtnName)}).addEventListener('click', function () {{
+					var aopts = document.querySelectorAll({JsValue($"#{availableListName} option:not(:disabled)")});
 					aopts.forEach(function (elem) {{
 						var newInp = document.createElement('input')
-						newInp.name = '{modelName}';
+						newInp.name = {JsValue(modelName)};
 						newInp.type = 'hidden';
 						newInp.value = elem.value;
 						newInp.setAttribute('v', elem.value);
-						document.getElementById('{modelContainer}').appendChild(newInp);
-						document.getElementById('{selectedListName}').appendChild(elem.cloneNode(true));
-						document.getElementById('{availableListName}').removeChild(elem);
+						document.getElementById({JsValue(modelContainer)}).appendChild(newInp);
+						document.getElementById({JsValue(selectedListName)}).appendChild(elem.cloneNode(true));
+						document.getElementById({JsValue(availableListName)}).removeChild(elem);
 					}});
 
 					sortLists();
 
 					if (aopts.length) {{
-						document.getElementById('{parentContainerName}').dispatchEvent(twoColumnChangeEvent);
+						document.getElementById({JsValue(parentContainerName)}).dispatchEvent(twoColumnChangeEvent);
 					}}
 				}});
 
-				document.getElementById('{removeBtnName}').addEventListener('click', function () {{
-					var sopts = document.querySelectorAll('#{selectedListName} option:checked');
+				document.getElementById({JsValue(removeBtnName)}).addEventListener('click', function () {{
+					var sopts = document.querySelectorAll({JsValue($"#{selectedListName} option:checked")});
 					sopts.forEach(function (elem) {{
-						document.getElementById('{availableListName}').appendChild(elem.cloneNode(true));
-						document.getElementById('{selectedListName}').removeChild(elem);
+						document.getElementById({JsValue(availableListName)}).appendChild(elem.cloneNode(true));
+						document.getElementById({JsValue(selectedListName)}).removeChild(elem);
 
-						document.querySelector('[name=""{modelName}""][v=""' + elem.value + '""]').remove();
+						document.querySelector({JsValue($@"[name=""{modelName}""][v=""'")} + elem.value + '""]').remove();
 					}});
 
 					sortLists();
 
 					if (sopts.length) {{
-						document.getElementById('{parentContainerName}').dispatchEvent(twoColumnChangeEvent);
+						document.getElementById({JsValue(parentContainerName)}).dispatchEvent(twoColumnChangeEvent);
 					}}
 				}});
 
-				document.getElementById('{removeAllBtnName}').addEventListener('click', function () {{
-					var sopts = document.querySelectorAll('#{selectedListName} option:not(:disabled)');
+				document.getElementById({JsValue(removeAllBtnName)}).addEventListener('click', function () {{
+					var sopts = document.querySelectorAll({JsValue($"#{selectedListName} option:not(:disabled)")});
 					sopts.forEach(function (elem) {{
-						document.getElementById('{availableListName}').appendChild(elem.cloneNode(true));
-						document.getElementById('{selectedListName}').removeChild(elem);
+						document.getElementById({JsValue(availableListName)}).appendChild(elem.cloneNode(true));
+						document.getElementById({JsValue(selectedListName)}).removeChild(elem);
 						
 					}});
 
-					var container = document.getElementById('{modelContainer}');
+					var container = document.getElementById({JsValue(modelContainer)});
 					while (container.lastChild) {{
 						container.removeChild(container.lastChild);
 					}}
@@ -238,13 +246,13 @@ namespace TASVideos.TagHelpers
 					sortLists();
 
 					if (sopts.length) {{
-						document.getElementById('{parentContainerName}').dispatchEvent(twoColumnChangeEvent);
+						document.getElementById({JsValue(parentContainerName)}).dispatchEvent(twoColumnChangeEvent);
 					}}
 				}});
 
 				function sortLists() {{
-					sortSelect(document.getElementById('{availableListName}'));
-					sortSelect(document.getElementById('{selectedListName}'));
+					sortSelect(document.getElementById({JsValue(availableListName)}));
+					sortSelect(document.getElementById({JsValue(selectedListName)}));
 				}}
 
 				function sortSelect(elem) {{
@@ -260,7 +268,7 @@ namespace TASVideos.TagHelpers
 					return;
 				}}
 			}};
-			{uniqueFuncName}();
+			{JsIdentifier(uniqueFuncName)}();
 			</script>";
 
 			output.Content.AppendHtml(script);

--- a/TASVideos/TagHelpers/TwoColumnSelectTagHelper.cs
+++ b/TASVideos/TagHelpers/TwoColumnSelectTagHelper.cs
@@ -163,7 +163,7 @@ namespace TASVideos.TagHelpers
 			// Script Tag
 			var uniqueFuncName = "twoColumnPicker" + context.UniqueId;
 			string script = $@"<script>function {JsIdentifier(uniqueFuncName)}() {{
-				var twoColumnChangeEvent = new CustomEvent({JsValue(modelName + "Change")}, {{ bubbles: true }});
+				var twoColumnChangeEvent = new CustomEvent({JsValue(modelName + "Changed")}, {{ bubbles: true }});
 
 				document.getElementById({JsValue(parentContainerName)}).listChangedCallback = null;
 

--- a/TASVideos/TagHelpers/TwoColumnSelectTagHelper.cs
+++ b/TASVideos/TagHelpers/TwoColumnSelectTagHelper.cs
@@ -159,6 +159,7 @@ namespace TASVideos.TagHelpers
 				_htmlGenerator.GenerateValidationMessage(ViewContext, IdList.ModelExplorer, IdList.Name, null, null, new { @class = "text-danger" }));
 
 			output.Content.AppendHtml("</div>");
+
 			// Script Tag
 			var uniqueFuncName = "twoColumnPicker" + context.UniqueId;
 			string script = $@"<script>function {JsIdentifier(uniqueFuncName)}() {{


### PR DESCRIPTION
This TagHelper stuff is an absolute mess.  I can't see why anyone would bet a single cent on using these """components""" in a real world project.  But here we are...

So, we add a bunch of helpers that properly escape things for particular contexts, and then use them whenever we make dynamic strings.  The syntax is awful and super error prone, but nothing in C# really can help out with that; something like JS tagged template literals or any language that allows embedded DSLs would be the real fix.  (Or switch to a component system that has solved these issues instead of shitting them all over the floor.)

The code here is needlessly defensive; there are plenty of places where strings come only from super trusted sources, or are manufactured in a predictable way so that escaping is not needed.  But that's a hard thing to determine in general and very non-scalable, as you need to do backwards analysis on every string everywhere that gets into one of these methods to see all of its possible origins, and as you refactor code you need to constantly redo those analyses and track the good vs bad strings.