### PR TITLE
Refactor and clean up some wiki things

### DIFF
--- a/TASVideos.Test/ViewComponents/ParamHelperTests.cs
+++ b/TASVideos.Test/ViewComponents/ParamHelperTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TASVideos.ViewComponents;
+using TASVideos.WikiEngine;
 
 namespace TASVideos.Test.ViewComponents
 {

--- a/TASVideos.WikiEngine/NodeImplementations.cs
+++ b/TASVideos.WikiEngine/NodeImplementations.cs
@@ -1,0 +1,397 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace TASVideos.WikiEngine.AST
+{
+	public class Text : INode
+	{
+		public NodeType Type => NodeType.Text;
+		public string Content { get; }
+		public int CharStart { get; }
+		public int CharEnd { get; set; }
+		public Text(int charStart, string content)
+		{
+			CharStart = charStart;
+			Content = content;
+		}
+
+		public void WriteHtmlDynamic(TextWriter w, WriterContext ctx)
+		{
+			foreach (var c in Content)
+			{
+				switch (c)
+				{
+					case '<':
+						w.Write("&lt;");
+						break;
+					case '&':
+						w.Write("&amp;");
+						break;
+					default:
+						w.Write(c);
+						break;
+				}
+			}
+		}
+
+		public INode Clone()
+		{
+			return (Text)MemberwiseClone();
+		}
+
+		public string InnerText(IWriterHelper h)
+		{
+			return Content;
+		}
+
+		public void DumpContentDescriptive(TextWriter w, string padding)
+		{
+			if (Content.Any(c => c < 0x20 && c != '\n' && c != '\t'))
+			{
+				w.Write(padding);
+				w.WriteLine("$UNPRINTABLE TEXT!!!");
+			}
+			else
+			{
+				var first = true;
+				foreach (var s in Content.Split('\n'))
+				{
+					if (first)
+					{
+						first = false;
+					}
+					else
+					{
+						w.Write(padding);
+						w.WriteLine("$LF");
+					}
+
+					if (s.Length > 0)
+					{
+						w.Write(padding);
+						w.Write('"');
+						w.WriteLine(s);
+					}
+				}
+			}
+		}
+
+		public IEnumerable<INode> CloneForToc()
+		{
+			return new[] { Clone() };
+		}
+	}
+
+	public class Element : INodeWithChildren
+	{
+		private static readonly Regex AllowedTagNames = new ("^[a-z0-9]+$");
+		private static readonly Regex AllowedAttributeNames = new ("^[a-z\\-]+$");
+		private static readonly HashSet<string> VoidTags = new ()
+		{
+			"area", "base", "br", "col", "embed", "hr", "img", "input",
+			"keygen", "link", "meta", "param", "source", "track", "wbr"
+		};
+		public NodeType Type => NodeType.Element;
+		public List<INode> Children { get; private set; } = new ();
+		public IDictionary<string, string> Attributes { get; private set; } = new Dictionary<string, string>();
+		public string Tag { get; }
+		public int CharStart { get; }
+		public int CharEnd { get; set; }
+		public Element(int charStart, string tag)
+		{
+			if (!AllowedTagNames.IsMatch(tag))
+			{
+				throw new InvalidOperationException("Invalid tag name");
+			}
+
+			if (tag == "script" || tag == "style")
+			{
+				// we don't escape for these
+				throw new InvalidOperationException("Unsupported tag!");
+			}
+
+			CharStart = charStart;
+			Tag = tag;
+		}
+
+		public Element(int charStart, string tag, IEnumerable<INode> children)
+			: this(charStart, tag)
+		{
+			Children.AddRange(children);
+		}
+
+		public Element(int charStart, string tag, IEnumerable<KeyValuePair<string, string>> attributes, IEnumerable<INode> children)
+			: this(charStart, tag, children)
+		{
+			foreach (var kvp in attributes)
+			{
+				Attributes.Add(kvp.Key, kvp.Value);
+			}
+		}
+
+		public void WriteHtmlDynamic(TextWriter w, WriterContext ctx)
+		{
+			if (VoidTags.Contains(Tag) && Children.Count > 0)
+			{
+				throw new InvalidOperationException("Void tag with child content!");
+			}
+
+			IEnumerable<KeyValuePair<string, string>> attrs = Attributes;
+			if (Tag == "td")
+			{
+				var style = ctx.RunTdStyleFilters(InnerText(ctx.Helper));
+				if (style != null)
+				{
+					attrs = attrs.Concat(new[] { new KeyValuePair<string, string>("style", style) });
+				}
+			}
+
+			w.Write('<');
+			w.Write(Tag);
+			foreach (var a in attrs)
+			{
+				if (!AllowedAttributeNames.IsMatch(a.Key))
+				{
+					throw new InvalidOperationException("Invalid attribute name");
+				}
+
+				w.Write(' ');
+				w.Write(a.Key);
+				w.Write("=\"");
+				foreach (var c in a.Value)
+				{
+					switch (c)
+					{
+						case '<':
+							w.Write("&lt;");
+							break;
+						case '&':
+							w.Write("&amp;");
+							break;
+						case '"':
+							w.Write("&quot;");
+							break;
+						default:
+							w.Write(c);
+							break;
+					}
+				}
+
+				w.Write('"');
+			}
+
+			if (VoidTags.Contains(Tag))
+			{
+				w.Write(" />");
+			}
+			else
+			{
+				w.Write('>');
+				foreach (var c in Children)
+				{
+					c.WriteHtmlDynamic(w, ctx);
+				}
+
+				w.Write("</");
+				w.Write(Tag);
+				w.Write('>');
+			}
+		}
+
+		public INode Clone()
+		{
+			var ret = (Element)MemberwiseClone();
+			ret.Children = Children.Select(c => c.Clone()).ToList();
+			ret.Attributes = new Dictionary<string, string>(Attributes);
+			return ret;
+		}
+
+		public string InnerText(IWriterHelper h)
+		{
+			return string.Join("", Children.Select(c => c.InnerText(h)));
+		}
+
+		public void DumpContentDescriptive(TextWriter w, string padding)
+		{
+			w.Write(padding);
+			w.Write('[');
+			w.Write(Tag);
+			w.Write(' ');
+			foreach (var kvp in Attributes.OrderBy(z => z.Key))
+			{
+				w.Write(kvp.Key);
+				w.Write('=');
+				w.Write(kvp.Value);
+				w.Write(' ');
+			}
+
+			w.WriteLine();
+			foreach (var child in Children)
+			{
+				child.DumpContentDescriptive(w, padding + '\t');
+			}
+
+			w.Write(padding);
+			w.Write(']');
+			w.Write(Tag);
+			w.WriteLine();
+		}
+
+		private static readonly HashSet<string> TocTagBlacklist = new ()
+		{
+			"a", "br"
+		};
+
+		public IEnumerable<INode> CloneForToc()
+		{
+			var children = Children.SelectMany(n => n.CloneForToc());
+			if (TocTagBlacklist.Contains(Tag))
+			{
+				return children;
+			}
+
+			var ret = (Element)MemberwiseClone();
+			ret.Children = children.ToList();
+			ret.Attributes = new Dictionary<string, string>(Attributes);
+			return new[] { ret };
+		}
+	}
+
+	public class IfModule : INodeWithChildren
+	{
+		public NodeType Type => NodeType.IfModule;
+		public List<INode> Children { get; private set; } = new ();
+		public string Condition { get; }
+		public int CharStart { get; }
+		public int CharEnd { get; set; }
+		public IfModule(int charStart, string condition)
+		{
+			CharStart = charStart;
+			Condition = condition;
+		}
+
+		public IfModule(int charStart, string condition, IEnumerable<INode> children)
+			: this(charStart, condition)
+		{
+			Children.AddRange(children);
+		}
+
+		public void WriteHtmlDynamic(TextWriter w, WriterContext ctx)
+		{
+			if (ctx.Helper.CheckCondition(Condition))
+			{
+				foreach (var c in Children)
+				{
+					c.WriteHtmlDynamic(w, ctx);
+				}
+			}
+		}
+
+		public INode Clone()
+		{
+			var ret = (IfModule)MemberwiseClone();
+			ret.Children = Children.Select(c => c.Clone()).ToList();
+			return ret;
+		}
+
+		public string InnerText(IWriterHelper h)
+		{
+			return h.CheckCondition(Condition)
+				? string.Join("", Children.Select(c => c.InnerText(h)))
+				: "";
+		}
+
+		public void DumpContentDescriptive(TextWriter w, string padding)
+		{
+			w.Write(padding);
+			w.Write("?IF ");
+			w.Write(Condition);
+			w.WriteLine();
+			foreach (var child in Children)
+			{
+				child.DumpContentDescriptive(w, padding + '\t');
+			}
+
+			w.Write(padding);
+			w.Write("?ENDIF ");
+			w.Write(Condition);
+			w.WriteLine();
+		}
+
+		public IEnumerable<INode> CloneForToc()
+		{
+			return new[] { Clone() };
+		}
+	}
+
+	public class Module : INode
+	{
+		public NodeType Type => NodeType.Module;
+		public string Text { get; }
+		public int CharStart { get; }
+		public int CharEnd { get; set; }
+		public Module(int charStart, int charEnd, string text)
+		{
+			CharStart = charStart;
+			CharEnd = charEnd;
+			Text = text;
+		}
+
+		public void WriteHtmlDynamic(TextWriter w, WriterContext ctx)
+		{
+			var pp = Text.Split(new[] { '|' }, 2);
+			var moduleName = pp[0];
+			var moduleParams = pp.Length > 1 ? pp[1] : "";
+			if (moduleName.ToLower() == "settableattributes")
+			{
+				if (!ctx.AddTdStyleFilter(moduleParams))
+				{
+					var div = new Element(CharStart, "div") { CharEnd = CharEnd };
+					div.Children.Add(new Text(CharStart, "Module Error for settableattributes: Couldn't parse parameter string " + moduleParams) { CharEnd = CharEnd });
+					div.Attributes["class"] = "module-error";
+					div.WriteHtmlDynamic(w, ctx);
+				}
+			}
+			else if (WikiModules.IsModule(moduleName))
+			{
+				ctx.Helper.RunViewComponent(w, moduleName, moduleParams);
+			}
+			else
+			{
+				var div = new Element(CharStart, "div") { CharEnd = CharEnd };
+				div.Children.Add(new Text(CharStart, "Unknown module " + moduleName) { CharEnd = CharEnd });
+				div.Attributes["class"] = "module-error";
+				div.WriteHtmlDynamic(w, ctx);
+			}
+		}
+
+		public INode Clone()
+		{
+			return (Module)MemberwiseClone();
+		}
+
+		public string InnerText(IWriterHelper h)
+		{
+			// could actually run the module here... but no.
+			return "";
+		}
+
+		public void DumpContentDescriptive(TextWriter w, string padding)
+		{
+			w.Write(padding);
+			w.Write('(');
+			w.Write(Text);
+			w.WriteLine(')');
+		}
+
+		public IEnumerable<INode> CloneForToc()
+		{
+			return Enumerable.Empty<INode>();
+		}
+	}
+}

--- a/TASVideos.WikiEngine/ParamHelper.cs
+++ b/TASVideos.WikiEngine/ParamHelper.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using TASVideos.Extensions;
 
-namespace TASVideos.ViewComponents
+namespace TASVideos.WikiEngine
 {
-	// ***************
-	// Parameter helpers
-	// These helpers assist with parsing wiki markup parameters from the user
-	// By design they need to gracefully handle all sorts of nonsense input from the user
-	// ***************
+	/// <summary>
+	/// Helpers for parsing parameters in wiki markup.
+	/// By design they need to gracefully handle all sorts of nonsense input from the user.
+	/// </summary>
 	public static class ParamHelper
 	{
 		/// <summary>
@@ -161,6 +159,52 @@ namespace TASVideos.ViewComponents
 			}
 
 			return GetValueFor(parameterStr, param).CsvToInts();
+		}
+	}
+
+	internal static class ExtensionsToJunkLater
+	{
+		/// <summary>
+		/// Takes a comma separated string and returns a list of values.
+		/// </summary>
+		public static IEnumerable<int> CsvToInts(this string? param)
+		{
+			if (string.IsNullOrWhiteSpace(param))
+			{
+				return Enumerable.Empty<int>();
+			}
+
+			var candidates = param.CsvToStrings();
+
+			var ids = new List<int>();
+			foreach (var candidate in candidates)
+			{
+				if (int.TryParse(candidate, out int parsed))
+				{
+					ids.Add(parsed);
+				}
+			}
+
+			return ids;
+		}
+
+		public static string[] SplitWithEmpty(this string str, string separator)
+		{
+			return str.Split(new[] { separator }, StringSplitOptions.RemoveEmptyEntries);
+		}
+
+		/// <summary>
+		/// Takes a comma separated string and returns a list of values.
+		/// </summary>
+		public static IEnumerable<string> CsvToStrings(this string? param)
+		{
+			// TODO: Rename this; this isn't "CSV".
+			return string.IsNullOrWhiteSpace(param)
+				? Enumerable.Empty<string>()
+				: param
+					.SplitWithEmpty(",")
+					.Where(p => !string.IsNullOrWhiteSpace(p))
+					.Select(p => p.Trim());
 		}
 	}
 }

--- a/TASVideos.WikiEngine/Util.cs
+++ b/TASVideos.WikiEngine/Util.cs
@@ -53,7 +53,7 @@ namespace TASVideos.WikiEngine
 
 			foreach (var r in results)
 			{
-				r.WriteHtmlDynamic(w, h);
+				r.WriteHtmlDynamic(w, new WriterContext(h));
 			}
 		}
 

--- a/TASVideos/TagHelpers/WikiMarkupTagHelper.cs
+++ b/TASVideos/TagHelpers/WikiMarkupTagHelper.cs
@@ -20,7 +20,6 @@ namespace TASVideos.TagHelpers
 	public class WikiMarkup : TagHelper, IWriterHelper
 	{
 		private readonly IViewComponentHelper _viewComponentHelper;
-		private readonly List<KeyValuePair<Regex, string>> _tableAttributeRunners = new ();
 
 		public WikiMarkup(IViewComponentHelper viewComponentHelper)
 		{
@@ -45,55 +44,9 @@ namespace TASVideos.TagHelpers
 			output.Content.SetHtmlContent(sw.ToString());
 		}
 
-		bool IWriterHelper.AddTdStyleFilter(string pp)
-		{
-			var regex = ParamHelper.GetValueFor(pp, "pattern");
-			var style = ParamHelper.GetValueFor(pp, "style");
-			if (string.IsNullOrWhiteSpace(regex) || string.IsNullOrWhiteSpace(style))
-			{
-				return false;
-			}
-
-			try
-			{
-				// TODO: What's actually going on with these @s?
-				if (regex[0] == '@')
-				{
-					regex = regex[1..];
-				}
-
-				if (regex[^1] == '@')
-				{
-					regex = regex[..^1];
-				}
-
-				var r = new Regex(regex, RegexOptions.None, TimeSpan.FromSeconds(1));
-				_tableAttributeRunners.Add(new KeyValuePair<Regex, string>(r, style));
-			}
-			catch
-			{
-				return false;
-			}
-
-			return true;
-		}
-
 		bool IWriterHelper.CheckCondition(string condition)
 		{
 			return HtmlExtensions.WikiCondition(ViewContext, condition);
-		}
-
-		string? IWriterHelper.RunTdStyleFilters(string text)
-		{
-			foreach (var (key, value) in _tableAttributeRunners)
-			{
-				if (key.Match(text).Success)
-				{
-					return value;
-				}
-			}
-
-			return null;
 		}
 
 		private static readonly IDictionary<string, Type> ViewComponents = Assembly


### PR DESCRIPTION
* Move responsibility for computing style filters into the wiki engine's rendering code.
  `IWriterHelper` is meant for things that have to come from some external source.  I stuffed style filters there because I didn't have anywhere else to put them, but let's do better now.
* Move a bunch of things out of `Node.cs` into `NodeImplementations.cs`
  File too big.
* Move ParamHelper into the wiki engine project.
  The big picture for this one is that because it's parsing work, it should be the responsibility of the wiki engine, and because our long term goals include reworking or replacing the wiki syntax, it shouldn't be something individual module-rendering-components need to know about.  This is a little sloppy for now, but in the future I hope to switch modules over to using a much cleaner API to get their `pp` values, which can then abstract better over different `pp` formats.