### PR TITLE
Responsive Design Updates

### DIFF
--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -16,34 +16,34 @@
 </div>
 <hr />
 <partial name="_Pager" model="Model.Forum.Topics" />
-
-<table class="table table-striped table-bordered">
-	<tr>
-		<th></th>
-		<th>Topics</th>
-		<th>Replies</th>
-		<th>Author</th>
-		<td>Views</td>
-		<td>Last Post</td>
-	</tr>
-	@foreach (var topic in Model.Forum.Topics)
-	{
-		<tr>
-			<td>
-				<span condition="@(topic.Type == ForumTopicType.Sticky)" class="fa fa-sticky-note"></span>
-				<span condition="@(topic.Type == ForumTopicType.Announcement)" class="fa fa-bullhorn"></span>
-			</td>
-			<td>
-				<a asp-page="/Forum/Topics/Index" asp-route-id="@topic.Id">
-					@Html.Raw(topic.Type.ToTitleHtml(topic.Title))
-				</a>
-			</td>
-			<td>@Math.Max(0, topic.PostCount - 1)</td> @*Imported Submission Topics will have no replies and no original post*@
-			<td>@topic.CreateUserName</td>
-			<td>@topic.Type</td>
-			<td><timezone-convert asp-for="@topic.LastPostDateTime" /></td>
-		</tr>
-	}
-</table>
+<div class="table-container">
+    <table class="table table-striped table-bordered">
+        <tr>
+            <th></th>
+            <th>Topics</th>
+            <th>Replies</th>
+            <th>Author</th>
+            <td>Views</td>
+            <td>Last Post</td>
+        </tr>
+        @foreach (var topic in Model.Forum.Topics) {
+            <tr>
+                <td>
+                    <span condition="@(topic.Type == ForumTopicType.Sticky)" class="fa fa-sticky-note"></span>
+                    <span condition="@(topic.Type == ForumTopicType.Announcement)" class="fa fa-bullhorn"></span>
+                </td>
+                <td>
+                    <a asp-page="/Forum/Topics/Index" asp-route-id="@topic.Id">
+                        @Html.Raw(topic.Type.ToTitleHtml(topic.Title))
+                    </a>
+                </td>
+                <td>@Math.Max(0, topic.PostCount - 1)</td> @*Imported Submission Topics will have no replies and no original post*@
+                <td>@topic.CreateUserName</td>
+                <td>@topic.Type</td>
+                <td><timezone-convert asp-for="@topic.LastPostDateTime" /></td>
+            </tr>
+        }
+    </table>
+</div>
 
 <partial name="_Pager" model="Model.Forum.Topics" />

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -6,8 +6,7 @@
 	<title>@(ViewData["Title"] != null ? ViewData["Title"] + " - " : "")TASVideos</title>
 
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-	<link rel="stylesheet" href="~/css/bootstrap.scss" />
-	<link rel="stylesheet" href="~/css/site.scss" />
+	<link rel="stylesheet" href="~/css/site.css" />
 	<link rel="stylesheet" href="~/lib/font-awesome/css/font-awesome.css"/>
 	
 	<link rel="stylesheet" href="~/css/diffview.css" />

--- a/TASVideos/Startup.cs
+++ b/TASVideos/Startup.cs
@@ -56,7 +56,7 @@ namespace TASVideos
 
 			services.AddWebOptimizer(pipeline =>
 			{
-				pipeline.CompileScssFiles();
+				pipeline.AddScssBundle("/css/site.css", "css/site.scss", "css/bootstrap.scss");
 			});
 		}
 

--- a/TASVideos/wwwroot/css/site.scss
+++ b/TASVideos/wwwroot/css/site.scss
@@ -46,11 +46,11 @@ body {
 }
 
 .btn {
-	font-size: .875rem
-}
+	font-size: .875rem;
 
-.btn-sm {
-	font-size: .750rem
+	&-sm {
+		font-size: .750rem;
+	}
 }
 
 h1 {
@@ -68,14 +68,16 @@ h1 {
     // border: 1px solid #430f76;
 }
 
-.wiki h1 {
-	margin-left: 0;
-	margin-bottom: 1rem;
-}
+.wiki {
+	h1 {
+		margin-left: 0;
+		margin-bottom: 1rem;
+	}
 
-.wiki div.p {
-	margin-top: 0;
-	margin-bottom: 1rem;
+	div.p {
+		margin-top: 0;
+		margin-bottom: 1rem;
+	}
 }
 
 h2 {
@@ -177,12 +179,14 @@ h4 {
 	
 }
 
-[data-toggle="collapse"] .fa::before {
-	content: "\f139";
-}
+[data-toggle="collapse"] {
+	.fa::before {
+		content: "\f139";
+	}
 
-[data-toggle="collapse"].collapsed .fa::before {
-	content: "\f13a";
+	&.collapsed .fa::before {
+		content: "\f13a";
+	}
 }
 
 .hiddenifmodule {
@@ -230,8 +234,11 @@ h4 {
 	float: right
 }
 
-/* Wiki Tables */
+.table-container {
+	overflow-x: auto;
+}
 
+/* Wiki Tables */
 article.wiki table {
 	width: 100%;
 	margin-bottom: 1rem;


### PR DESCRIPTION
Part 1: Tables
Starting out with a hotfix for viewing tables on mobile with a current example on the subforum pages. To make table elements mobile friendly you can wrap them in a div with overflow-x "auto" - however this is still not truly responsive. To be fully responsive I would wonder if the other devs are open to switching to flexbox instead of pure html table elements.

Part 2: CSS Compilation
Whatever SCSS/SASS compiler we use should generate files with extension .css to avoid the possibility of having to do extra server configuration for mime types. I added a commit to fix this, but it has other outstanding issues. Our CSS and JS compilers/optimizers should be capable of outputting sourcemaps, and I would even suggest having them on in production of the site is going to be open source, but ligersharks's weboptimizer.Sass has no sourcemap support at all. Are the other devs open to switching to something with sourcemap support if/when that exists?