### PR TITLE
Fix CSS priority

### DIFF
--- a/TASVideos/Startup.cs
+++ b/TASVideos/Startup.cs
@@ -56,7 +56,7 @@ namespace TASVideos
 
 			services.AddWebOptimizer(pipeline =>
 			{
-				pipeline.AddScssBundle("/css/site.css", "css/site.scss", "css/bootstrap.scss");
+				pipeline.AddScssBundle("/css/site.css", "css/bootstrap.scss", "css/site.scss");
 			});
 		}
 


### PR DESCRIPTION
When I set up .css output for WebOptimzer.sass I bundled the files in the wrong order, fixes some headers being too large