### PR TITLE
WIP: Port Asynchronous YT Player from runs.tas.bot

### DIFF
--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -43,12 +43,45 @@
 	<h1>@($"Submission {Model.Submission.Title}")</h1>
 }
 
-<row>
-	<div class="col-lg-6" condition="hasEncode">
-		<iframe type="text/html" style="width:450px;height:370px;margin:0;" src="@Model.Submission!.EncodeEmbedLink" allowfullscreen="true"></iframe>
-		<br />
-		<a href="@Model.Submission!.EncodeEmbedLink">(Link to video)</a>
-	</div>
+<row class="mt-2">
+    <div class="col-lg-6" condition="hasEncode">
+		@*Boilerplate boostrap stuff *@
+        <div class="embed-responsive embed-responsive-16by9">
+            <div class="embed-responsive-item">
+                <div id="ytplayer"></div>
+            </div>
+        </div>
+        <script>
+            const youtubeScriptId = 'youtube-api';
+            let youtubeScript = document.getElementById(youtubeScriptId);
+			let player;
+			@*Loads the scripts which run the Youtube Player API asynchronously*@
+            if (youtubeScript === null) {
+                let tag = document.createElement('script');
+                let firstScript = document.getElementsByTagName('script')[0];
+
+                tag.src = 'https://www.youtube.com/iframe_api';
+                tag.id = youtubeScriptId;
+                firstScript.parentNode.insertBefore(tag, firstScript);
+            }
+			@*Populates the youtube player after the API script is ready*@
+			if (!player) {
+				@{
+					if (!String.IsNullOrEmpty(Model.Submission!.EncodeEmbedLink)){
+						<text>
+							window.onYouTubeIframeAPIReady = () => {
+								player = new YT.Player('ytplayer', {
+									videoId: "@Model.Submission!.EncodeEmbedLink.Split("/").Last()"
+								});
+							}
+						</text>
+					}
+				}
+			}
+        </script>
+        <br />
+        <a href="@Model.Submission!.EncodeEmbedLink">(Link to video)</a>
+    </div>
 	<div class="@(hasEncode ? "col-lg-6" : "col-lg-12")">
 		<div class="alert alert-@(statusColor)" role="alert">
 			<h4 condition="!Model.IsPublished" class="alert-heading">

--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -44,44 +44,44 @@
 }
 
 <row class="mt-2">
-    <div class="col-lg-6" condition="hasEncode">
+	<div class="col-lg-6" condition="hasEncode">
 		@*Boilerplate boostrap stuff *@
-        <div class="embed-responsive embed-responsive-16by9">
-            <div class="embed-responsive-item">
-                <div id="ytplayer"></div>
-            </div>
-        </div>
-        <script>
-            const youtubeScriptId = 'youtube-api';
-            let youtubeScript = document.getElementById(youtubeScriptId);
+		<div class="embed-responsive embed-responsive-16by9">
+			<div class="embed-responsive-item">
+				<div id="ytplayer"></div>
+			</div>
+		</div>
+		<script>
+			const youtubeScriptId = 'youtube-api';
+			let youtubeScript = document.getElementById(youtubeScriptId);
 			let player;
 			@*Loads the scripts which run the Youtube Player API asynchronously*@
-            if (youtubeScript === null) {
-                let tag = document.createElement('script');
-                let firstScript = document.getElementsByTagName('script')[0];
-
-                tag.src = 'https://www.youtube.com/iframe_api';
-                tag.id = youtubeScriptId;
-                firstScript.parentNode.insertBefore(tag, firstScript);
-            }
+			if (youtubeScript === null) {
+				let tag = document.createElement('script');
+				let firstScript = document.getElementsByTagName('script')[0];
+				
+				tag.src = 'https://www.youtube.com/iframe_api';
+				tag.id = youtubeScriptId;
+				firstScript.parentNode.insertBefore(tag, firstScript);
+			}
 			@*Populates the youtube player after the API script is ready*@
 			if (!player) {
 				@{
-					if (!String.IsNullOrEmpty(Model.Submission!.EncodeEmbedLink)){
-						<text>
-							window.onYouTubeIframeAPIReady = () => {
-								player = new YT.Player('ytplayer', {
-									videoId: "@Model.Submission!.EncodeEmbedLink.Split("/").Last()"
-								});
-							}
-						</text>
-					}
+				if (!String.IsNullOrEmpty(Model.Submission!.EncodeEmbedLink)){
+					<text>
+						window.onYouTubeIframeAPIReady = () => {
+							player = new YT.Player('ytplayer', {
+								videoId: "@Model.Submission!.EncodeEmbedLink.Split("/").Last()"
+							});
+						}
+					</text>
+				}
 				}
 			}
-        </script>
-        <br />
-        <a href="@Model.Submission!.EncodeEmbedLink">(Link to video)</a>
-    </div>
+		</script>
+		<br />
+		<a href="@Model.Submission!.EncodeEmbedLink">(Link to video)</a>
+	</div>
 	<div class="@(hasEncode ? "col-lg-6" : "col-lg-12")">
 		<div class="alert alert-@(statusColor)" role="alert">
 			<h4 condition="!Model.IsPublished" class="alert-heading">


### PR DESCRIPTION
Ports code that loads the YT player asynchronously, allowing for extensibility in case we ever want to support a dynamic player for multiple encodes or for players from different video hosts. It also improves page load behavior to delay loading the player.

Caveat: not sure how this is or is not related to the wikimodule youtube player, which didn't seem to be used in the submission template.
Also caveat, I am not remotely an expert with Razor syntax and my usage is probably horrifying

Also cleans up styling slightly around the top margin