### PR TITLE
Change display of movie times to compacted version

### DIFF
--- a/TASVideos.Common/ITimeable.cs
+++ b/TASVideos.Common/ITimeable.cs
@@ -29,7 +29,22 @@ namespace TASVideos.Common
 				return TimeSpan.MaxValue;
 			}
 
-			return TimeSpan.FromMilliseconds(Math.Round(timeable.Frames / timeable.FrameRate * 100) * 10);
+			return TimeSpan.FromMilliseconds(Math.Round(timeable.Frames / timeable.FrameRate * 100, MidpointRounding.AwayFromZero) * 10);
+		}
+
+		public static string ToStringWithOptionalDaysAndHours(this TimeSpan timeSpan)
+		{
+			if (timeSpan.Days >= 1)
+			{
+				return timeSpan.ToString(@"d\:hh\:mm\:ss\.ff");
+			}
+
+			if (timeSpan.Hours >= 1)
+			{
+				return timeSpan.ToString(@"h\:mm\:ss\.ff");
+			}
+
+			return timeSpan.ToString(@"mm\:ss\.ff");
 		}
 	}
 }

--- a/TASVideos.Data/Entity/Publication.cs
+++ b/TASVideos.Data/Entity/Publication.cs
@@ -123,7 +123,7 @@ namespace TASVideos.Data.Entity
 				$"{System.Code} {Game.DisplayName}"
 				+ (!string.IsNullOrWhiteSpace(Branch) ? $" \"{Branch}\" " : "")
 				+ $" by {string.Join(", ", authorList)}"
-				+ $" in {this.Time().ToString("g", CultureInfo.InvariantCulture)}";
+				+ $" in {this.Time().ToStringWithOptionalDaysAndHours()}";
 		}
 	}
 

--- a/TASVideos.Data/Entity/Submission.cs
+++ b/TASVideos.Data/Entity/Submission.cs
@@ -129,7 +129,7 @@ namespace TASVideos.Data.Entity
 			Title =
 			$"#{Id}: {string.Join(", ", authorList)}'s {System.Code} {GameName}"
 				+ (!string.IsNullOrWhiteSpace(Branch) ? $" \"{Branch}\" " : "")
-				+ $" in {this.Time().ToString("g", CultureInfo.InvariantCulture)}";
+				+ $" in {this.Time().ToStringWithOptionalDaysAndHours()}";
 		}
 
 		// Temporary for import debugging

--- a/TASVideos.ForumEngine/Node.cs
+++ b/TASVideos.ForumEngine/Node.cs
@@ -323,7 +323,7 @@ namespace TASVideos.ForumEngine
 							FrameRate = fps,
 							Frames = n
 						};
-						var time = timeable.Time().ToString("g");
+						var time = timeable.Time().ToStringWithOptionalDaysAndHours();
 
 						w.Write("<abbr title=");
 						Helpers.WriteAttributeValue(w, $"{n} Frames @{fps} FPS");

--- a/TASVideos/Pages/Shared/Components/FrontpageSubmissionList/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/FrontpageSubmissionList/Default.cshtml
@@ -14,7 +14,7 @@
 		<tr>
 			<td><sub-link id="item.Id">@item.System @item.GameName @(!string.IsNullOrWhiteSpace(item.Branch) ? $"\"{item.Branch}\"" : "")</sub-link></td>
 			<td>@item.Branch</td>
-			<td>@($"{item.Time:g}")</td>
+			<td>@(item.Time.ToStringWithOptionalDaysAndHours())</td>
 			<td>@item.Author</td>
 			<td><timezone-convert asp-for="@item.Submitted" date-only="true" /></td>
 			<td>@item.Status.EnumDisplayName()</td>

--- a/TASVideos/Pages/Shared/Components/TabularMovieList/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/TabularMovieList/Default.cshtml
@@ -26,9 +26,9 @@
 							<td><timezone-convert asp-for="@pub.CreateTimestamp" date-only="true" /></td>
 							<td>@pub.Game</td>
 							<td>
-								<pub-link id="pub.Id">@($"{pub.Time():g}")</pub-link>
+								<pub-link id="pub.Id">@(pub.Time().ToStringWithOptionalDaysAndHours())</pub-link>
 								<span condition="pub.ObsoletedMovie != null">
-									(Was <pub-link id="pub.ObsoletedMovie!.Id">@($"{pub.ObsoletedMovie!.Time():g}")</pub-link>)
+									(Was <pub-link id="pub.ObsoletedMovie!.Id">@(pub.ObsoletedMovie!.Time().ToStringWithOptionalDaysAndHours())</pub-link>)
 								</span>
 							</td>
 							<td>@pub.Authors</td>

--- a/TASVideos/Pages/Submissions/Index.cshtml
+++ b/TASVideos/Pages/Submissions/Index.cshtml
@@ -93,7 +93,7 @@
 			<td>@item.System</td>
 			<td><sub-link id="item.Id">@item.GameName</sub-link></td>
 			<td>@item.Branch</td>
-			<td>@($"{item.Time:g}")</td>
+			<td>@(item.Time.ToStringWithOptionalDaysAndHours())</td>
 			<td>@item.Author</td>
 			<td><timezone-convert asp-for="@item.Submitted" date-only="true" /></td>
 			<td>

--- a/tests/TASVideos.Common.Tests/TimeableTests.cs
+++ b/tests/TASVideos.Common.Tests/TimeableTests.cs
@@ -6,21 +6,20 @@ namespace TASVideos.Common.Tests
 	public class TimeableTests
 	{
 		[TestMethod]
-		[DataRow(60.1, 421, "0:00:07")]
-		[DataRow(75, 2346, "0:00:31.28")]
+		[DataRow(60.1, 421, "00:07.00")]
+		[DataRow(75, 2346, "00:31.28")]
 		[DataRow(60, 412521, "1:54:35.35")]
-		[DataRow(58.643, 5213, "0:01:28.89")]
-		[DataRow(62.5, 11221, "0:02:59.54")]
-		[DataRow(50, 6666, "0:02:13.32")]
+		[DataRow(58.643, 5213, "01:28.89")]
+		[DataRow(62.5, 11221, "02:59.54")]
+		[DataRow(50, 6666, "02:13.32")]
 		[DataRow(60.09, 325523, "1:30:17.26")]
-		[DataRow(60, 16997, "0:04:43.28")]
-		[DataRow(60, 0, "0:00:00")]
-		[DataRow(0, 1, "10675199:2:48:05.4775807")]
+		[DataRow(60, 16997, "04:43.28")]
+		[DataRow(60, 0, "00:00.00")]
+		[DataRow(0, 1, "10675199:02:48:05.47")]
 		public void TimeableTimespanTest(double frameRate, int frames, string expected)
 		{
 			var actual = new Timeable { FrameRate = frameRate, Frames = frames }
-				.Time()
-				.ToString("g");
+				.Time().ToStringWithOptionalDaysAndHours();
 			Assert.AreEqual(expected, actual);
 		}
 	}


### PR DESCRIPTION
TimeSpan has no way of easily create strings with optional hours or even days. So just make one.
This recreates the old display system where hours are only shown if they aren't 0. Same with days. Only minutes, seconds, and centiseconds always appear and are always two digits.
See the adjusted tests for examples.