### PR TITLE
Redesign of the publication page

### DIFF
--- a/TASVideos/Pages/Publications/Index.cshtml
+++ b/TASVideos/Pages/Publications/Index.cshtml
@@ -10,4 +10,6 @@
 	<partial name="_MovieModule" model="movie" />
 	<br />
 }
-@await Component.RenderWiki("System/MovieLinkInstruction")
+<div class="text-muted">
+    @await Component.RenderWiki("System/MovieLinkInstruction")
+</div>

--- a/TASVideos/Pages/Publications/Index.cshtml
+++ b/TASVideos/Pages/Publications/Index.cshtml
@@ -8,6 +8,6 @@
 @foreach (var movie in Model.Movies)
 {
 	<partial name="_MovieModule" model="movie" />
-	<hr />
+	<br />
 }
 @await Component.RenderWiki("System/MovieLinkInstruction")

--- a/TASVideos/Pages/Publications/View.cshtml
+++ b/TASVideos/Pages/Publications/View.cshtml
@@ -6,7 +6,10 @@
 @section PageTitle { }
 
 <partial name="_MovieModule" model="Model.Publication" />
-@await Component.RenderWiki("System/MovieLinkInstruction")
+<hr />
+<div class="text-muted">
+	@await Component.RenderWiki("System/MovieLinkInstruction")
+</div>
 <small>
 	last edited by @Model.Publication.LastUpdateUser on @Model.Publication.LastUpdateTimestamp
 </small>

--- a/TASVideos/Pages/Publications/View.cshtml
+++ b/TASVideos/Pages/Publications/View.cshtml
@@ -3,11 +3,7 @@
 @{
 	ViewData["Title"] = $"Movie #{Model.Id}";
 }
-@section PageTitle {
-	<div class="container">
-		<h1 class="m-0 w-100 publication-header">Publication @Model.Publication.Id</h1>
-	</div>
-}
+@section PageTitle { }
 
 <partial name="_MovieModule" model="Model.Publication" />
 @await Component.RenderWiki("System/MovieLinkInstruction")

--- a/TASVideos/Pages/Shared/Components/DisplayMiniMovie/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/DisplayMiniMovie/Default.cshtml
@@ -11,7 +11,7 @@
                 <div class="pull-left pr-3 pb-1" style="max-width: 80%">
                     <img class="pb-1" src="~/media/@Model.Screenshot.Path" alt="@Model.Screenshot.Description" />
                     <br />
-                    <a href="@Model.OnlineWatchingUrl" class="btn btn-primary">Watch</a>
+                    <a href="@Model.OnlineWatchingUrl" class="btn btn-primary" target="_blank">Watch</a>
                 </div>
 			</pub-link>
 			@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)

--- a/TASVideos/Pages/Shared/Components/DisplayMiniMovie/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/DisplayMiniMovie/Default.cshtml
@@ -2,16 +2,19 @@
 
 <div condition="Model != null" style="max-height: 440px; overflow-y: auto">
 	<div class="card">
-		<div class="card-header">
+		<div class="card-header bg-bgprimary">
 			<h5><span class="pull-right badge badge-info m-1">Featured</span></h5>
-			<h4>@Model.Title</h4>
+            <h4><pub-link id="Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></pub-link></h4>
 		</div>
-		<div class="card-body">
+		<div class="card-body bg-bgsecondary">
 			<pub-link id="Model.Id">
-				<img src="~/media/@Model.Screenshot.Path" alt="@Model.Screenshot.Description" class="pull-left pr-3 pb-1" style="max-width: 80%" />
+                <div class="pull-left pr-3 pb-1" style="max-width: 80%">
+                    <img class="pb-1" src="~/media/@Model.Screenshot.Path" alt="@Model.Screenshot.Description" />
+                    <br />
+                    <a href="@Model.OnlineWatchingUrl" class="btn btn-primary">Watch</a>
+                </div>
 			</pub-link>
 			@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
-			<a href="@Model.OnlineWatchingUrl" class="btn btn-primary">Watch</a>
 		</div>
 	</div>
 </div>

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -67,7 +67,7 @@
 	}
 	else
 	{
-		<h1 class="mb-2 container">@title</h1>
+		<h1 class="mb-2 container bg-secondary">@title</h1>
 	}
 
 <div class="container">

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -37,7 +37,7 @@
 	}
 }
 <card class="border border-primary">
-	<cardheader>
+	<cardheader class="bg-bgprimary">
 		<img class="pixelart-image" condition="!string.IsNullOrWhiteSpace(Model.TierIconPath)" src="/@Model.TierIconPath" /> <h4 class="m-0"><a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></a></h4>
 		<div class="pull-right">
 			@foreach (var flag in Model.Flags.Where(f => !string.IsNullOrWhiteSpace(f.IconPath)))
@@ -48,17 +48,17 @@
 			}
 		</div>
 	</cardheader>
-	<cardbody>
-        <row>
-            <div condition="@Model.ObsoletedById.HasValue" class="col card-subtitle text-danger">
+    <cardbody class="px-3 py-0">
+        <div condition="@Model.ObsoletedById.HasValue" class="col card-subtitle text-danger my-2">
+            <row>
                 <b>This movie has been obsoleted!</b>
-				<br />
+            </row>
+            <row>
                 <pub-link id="Model.ObsoletedById!.Value" class="btn btn-danger btn-sm">Obsoleting Movie</pub-link>
-            </div>
-        </row>
-		<hr />
-		<row>
-            <div class="col-md-4 mb-4 mb-md-0 text-center">
+            </row>
+        </div>
+        <row class="bg-bgsecondary py-3">
+            <div class="col-auto mb-4 mb-md-0 mx-auto text-center text-md-left">
                 <div>
                     <img src="~/media/@Model.Screenshot.Path"
                          alt="@Model.Screenshot.Description"
@@ -99,84 +99,83 @@
                    class="btn btn-secondary btn-sm mt-1">
                     Logs
                 </a>
+                <br />
+                <div>
+                    <span permission="RateMovies">
+                        <a asp-page="/Publications/Rate"
+                           asp-route-id="@Model.Id"
+                           asp-route-returnUrl="@Context.ReturnUrl()">
+                            Rating
+                        </a>: &nbsp;
+                    </span>
+                    <span condition="!ViewData.UserHas(PermissionTo.RateMovies)">Rating:</span>
+                    <span condition="Model.RatingCount > 2">@Math.Round(Model.OverallRating ?? 0, 2)</span>
+                    <span condition="Model.RatingCount <= 2">(Too few votes to display rating)</span>
+                    <span>(<a asp-page="/Ratings/Index" asp-route-id="@Model.Id">@Model.RatingCount votes</a>)</span>
+                </div>
+                @foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
+                {
+                    <partial name="_Award" model="award" />
+                }
             </div>
-			<div class="col-md-7">
-				<fullrow>
-					<div><small>@Model.CreateTimestamp.Date.ToShortDateString()</small></div>
-					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
-				</fullrow>
-				<fullrow>
-					<div>
-						<span permission="RateMovies">
-							<a asp-page="/Publications/Rate"
-							   asp-route-id="@Model.Id"
-							   asp-route-returnUrl="@Context.ReturnUrl()">
-								Rating
-							</a>: &nbsp;
-						</span>
-						<span condition="!ViewData.UserHas(PermissionTo.RateMovies)">Rating:</span>
-						<span condition="Model.RatingCount > 2">@Math.Round(Model.OverallRating ?? 0, 2)</span>
-						<span condition="Model.RatingCount <= 2">(Too few votes to display rating)</span>
-						<span>(<a asp-page="/Ratings/Index" asp-route-id="@Model.Id">@Model.RatingCount votes</a>)</span>
-					</div>
-				</fullrow>
-			</div>
-			@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
-			{
-				<partial name="_Award" model="award" />
-			}
-		</row>
-		<hr />
-        <row>
-            <div class="col">
-                <row condition="Model.ObsoletedMovies.Any()">
-                    @foreach (var obsoletedMovie in Model.ObsoletedMovies)
-                    {
-                        <column class="mt-2 mb-2">
-                            Obsoletes:<br />
-                            <pub-link id="obsoletedMovie.Id">@obsoletedMovie.Title</pub-link>
-                        </column>
-                    }
-                </row>
-				<hr />
-                <row>
-                    <div class="col-lg-4">
-                        <div condition="Model.MovieFileLinks.Any()" class="mt-2">
-                            @foreach (var file in Model.MovieFileLinks)
-                            {
-                                <a title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a>
-                            }
-                        </div>
-                    </div>
-                    @foreach (var torrent in Model.TorrentLinks)
-                    {
-                        <a class="col-lg-4" href="~/torrent/@torrent.Path">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
-                    }
-                    <a class="col-lg-4" condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl">A/V file via Mirror</a>
-                </row>
-                <row>
-                    <div class="col-md-2">
-                        <small condition="Model.GenreTags.Any()">
-                            Genre:<br />
-                            @foreach (var genre in Model.GenreTags)
-                            {
-                                <a href="/Movies-@genre.Code">@genre.DisplayName</a>
-                            }
-                            <br />
-                        </small>
-                        <small condition="Model.Tags.Any()">
-                            Tags:<br />
-                            @foreach (var tag in Model.Tags)
-                            {
-                                <a href="/Movies-@tag.Code">@tag.DisplayName</a><br />
-                            }
-                        </small>
-                        <small condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
-                            Emulator Version:<br />@Model.EmulatorVersion
-                        </small>
-                    </div>
-                </row>
+            <div class="col-md">
+                <fullrow>
+                    <div><small>@Model.CreateTimestamp.Date.ToShortDateString()</small></div>
+                    @await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
+                </fullrow>
             </div>
         </row>
-	</cardbody>
+        <row condition="Model.ObsoletedMovies.Any()" class="border-bottom mb-2">
+            @foreach (var obsoletedMovie in Model.ObsoletedMovies)
+            {
+                <column class="mt-2 mb-2">
+                    Obsoletes:<br />
+                    <pub-link id="obsoletedMovie.Id">@obsoletedMovie.Title</pub-link>
+                </column>
+            }
+        </row>
+        <row class="mb-2">
+            <div class="col-auto">
+                <small condition="Model.GenreTags.Any()">
+                    Genre:<br />
+                    @foreach (var genre in Model.GenreTags)
+                    {
+                        <a href="/Movies-@genre.Code">@genre.DisplayName</a>
+                    }
+                    <br />
+                </small>
+                <small condition="Model.Tags.Any()">
+                    Tags:<br />
+                    @foreach (var tag in Model.Tags)
+                    {
+                        <a href="/Movies-@tag.Code" class="ml-2">@tag.DisplayName</a><br />
+                    }
+                </small>
+            </div>
+            <a class="col-lg-4" condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl">A/V file via Mirror</a>
+            <div class="col-auto">
+                <div condition="Model.MovieFileLinks.Any()" class="col-lg-4">
+                    <div class="mt-2">
+                        @foreach (var file in Model.MovieFileLinks)
+                        {
+                            <a title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a>
+                        }
+                    </div>
+                </div>
+                <small condition="Model.TorrentLinks.Any()">
+                    Torrents:<br />
+                    @foreach (var torrent in Model.TorrentLinks)
+                    {
+                        <a href="~/torrent/@torrent.Path" class="ml-2">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
+                        <br />
+                    }
+                </small>
+            </div>
+            <div class="col-auto">
+                <small condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
+                    Emulator Version:<br /><span class="ml-2">@Model.EmulatorVersion</span>
+                </small>
+            </div>
+        </row>
+    </cardbody>
 </card>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -36,14 +36,9 @@
 		return "";
 	}
 }
-
-<div condition="@Model.ObsoletedById.HasValue" class="card-header text-danger pt-2 pb-2 bg-white">
-	<pub-link id="@Model.ObsoletedById!.Value" class="btn btn-sm btn-primary bg-danger border-danger">This movie has been obsoleted</pub-link>
-</div>
-<card class="border-0 rounded-bottom">
-	<cardheader class="d-flex flex-row align-items-center">
-		<img class="pixelart-image" condition="!string.IsNullOrWhiteSpace(Model.TierIconPath)" src="/@Model.TierIconPath" />
-        <h4 class="m-0 ml-2 mr-2">@Model.Title</h4>
+<card class="border border-primary">
+	<cardheader>
+		<img class="pixelart-image" condition="!string.IsNullOrWhiteSpace(Model.TierIconPath)" src="/@Model.TierIconPath" /> <h4 class="m-0"><a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></a></h4>
 		<div class="pull-right">
 			@foreach (var flag in Model.Flags.Where(f => !string.IsNullOrWhiteSpace(f.IconPath)))
 			{
@@ -54,74 +49,58 @@
 		</div>
 	</cardheader>
 	<cardbody>
+        <row>
+            <div condition="@Model.ObsoletedById.HasValue" class="col card-subtitle text-danger">
+                <b>This movie has been obsoleted!</b>
+				<br />
+                <pub-link id="Model.ObsoletedById!.Value" class="btn btn-danger btn-sm">Obsoleting Movie</pub-link>
+            </div>
+        </row>
+		<hr />
 		<row>
-			<div class="col-md-3">
-				<div>
-					<img src="~/media/@Model.Screenshot.Path"
-						 alt="@Model.Screenshot.Description"
-						 title="@Model.Screenshot.Description"
-						 class="w-100 pixelart-image"
-						 loading="lazy" />
-				</div>
-				@foreach (var url in Model.OnlineWatchingUrls)
-				{
-					<a href="@url" class="btn btn-primary btn-sm mt-1">Watch</a>
-				}
-				<a asp-page="View" asp-route-id="@Model.Id" class="btn btn-secondary btn-sm mt-1">Publication</a>
-				<a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1">Submission</a>
-				<a permission="EditPublicationMetaData"
-				   asp-page="Edit"
-				   asp-route-id="@Model.Id"
-				   class="btn btn-secondary btn-sm mt-1">Edit</a>
-				<a permission="CatalogMovies"
-				   asp-page="/Publications/Catalog"
-				   asp-route-id="@Model.Id"
-				   class="btn btn-secondary btn-sm mt-1">Catalog</a>
-				<a condition="@Model.TopicId > 0"
-				   asp-page="/Forum/Topics/Index"
-				   asp-route-id="@Model.TopicId"
-				   class="btn btn-secondary btn-sm mt-1">
-					Discuss
-				</a>
-				<a asp-page="/Games/PublicationHistory"
-					asp-route-id="@Model.GameId"
-					asp-route-highlight="@Model.Id"
-					class="btn btn-secondary btn-sm mt-1">
-					History
-				</a>
-				<a
-					permission="EditPublicationMetaData"
-					href="/MovieMaintenanceLog?id=@Model.Id"
-					class="btn btn-secondary btn-sm mt-1">
-					Logs
-				</a>
-			</div>
+            <div class="col-md-4 mb-4 mb-md-0 text-center">
+                <div>
+                    <img src="~/media/@Model.Screenshot.Path"
+                         alt="@Model.Screenshot.Description"
+                         title="@Model.Screenshot.Description"
+                         class="w-100 pixelart-image"
+                         loading="lazy" />
+                </div>
+                @foreach (var url in Model.OnlineWatchingUrls)
+                {
+                    <a href="@url" class="btn btn-primary btn-sm mt-1">Watch</a>
+                }
+                <a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1">Download (@System.IO.Path.GetExtension(Model.MovieFileName))</a>
+                <br />
+                <a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1">Submission</a>
+                <br />
+                <a permission="EditPublicationMetaData"
+                   asp-page="Edit"
+                   asp-route-id="@Model.Id"
+                   class="btn btn-secondary btn-sm mt-1">Edit</a>
+                <a permission="CatalogMovies"
+                   asp-page="/Publications/Catalog"
+                   asp-route-id="@Model.Id"
+                   class="btn btn-secondary btn-sm mt-1">Catalog</a>
+                <a condition="@Model.TopicId > 0"
+                   asp-page="/Forum/Topics/Index"
+                   asp-route-id="@Model.TopicId"
+                   class="btn btn-secondary btn-sm mt-1">
+                    Discuss
+                </a>
+                <a asp-page="/Games/PublicationHistory"
+                   asp-route-id="@Model.GameId"
+                   asp-route-highlight="@Model.Id"
+                   class="btn btn-secondary btn-sm mt-1">
+                    History
+                </a>
+                <a permission="EditPublicationMetaData"
+                   href="/MovieMaintenanceLog?id=@Model.Id"
+                   class="btn btn-secondary btn-sm mt-1">
+                    Logs
+                </a>
+            </div>
 			<div class="col-md-7">
-				<row>
-					<div class="col-lg-4">
-						<a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id">Movie file (@System.IO.Path.GetExtension(Model.MovieFileName))</a>
-						<div condition="Model.MovieFileLinks.Any()" class="mt-2">
-							@foreach (var file in Model.MovieFileLinks)
-							{
-								<a title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a>
-							}
-						</div>
-					</div>
-					@foreach (var torrent in Model.TorrentLinks)
-					{
-						<a class="col-lg-4" href="~/torrent/@torrent.Path">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
-					}
-					<a class="col-lg-4" condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl">A/V file via Mirror</a>
-				</row>
-				<row condition="Model.ObsoletedMovies.Any()">
-					@foreach (var obsoletedMovie in Model.ObsoletedMovies)
-					{
-						<column class="mt-2 mb-2">
-							Obsoletes:<br />
-							<pub-link id="obsoletedMovie.Id">@obsoletedMovie.Title</pub-link>
-						</column>
-					}
-				</row>
 				<fullrow>
 					<div><small>@Model.CreateTimestamp.Date.ToShortDateString()</small></div>
 					@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
@@ -142,30 +121,62 @@
 					</div>
 				</fullrow>
 			</div>
-			<div class="col-md-2">
-				<small condition="Model.GenreTags.Any()">
-					Genre:<br />
-					@foreach (var genre in Model.GenreTags)
-					{
-						<a href="/Movies-@genre.Code">@genre.DisplayName</a>
-					}
-					<br />
-				</small>
-				<small condition="Model.Tags.Any()">
-					Tags:<br />
-					@foreach (var tag in Model.Tags)
-					{
-						<a href="/Movies-@tag.Code">@tag.DisplayName</a><br />
-					}
-				</small>
-				<small condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
-					Emulator Version:<br />@Model.EmulatorVersion
-				</small>
-			</div>
 			@foreach (var award in publicationAwards.OrderByDescending(a => a.Year))
 			{
 				<partial name="_Award" model="award" />
 			}
 		</row>
+		<hr />
+        <row>
+            <div class="col">
+                <row condition="Model.ObsoletedMovies.Any()">
+                    @foreach (var obsoletedMovie in Model.ObsoletedMovies)
+                    {
+                        <column class="mt-2 mb-2">
+                            Obsoletes:<br />
+                            <pub-link id="obsoletedMovie.Id">@obsoletedMovie.Title</pub-link>
+                        </column>
+                    }
+                </row>
+				<hr />
+                <row>
+                    <div class="col-lg-4">
+                        <div condition="Model.MovieFileLinks.Any()" class="mt-2">
+                            @foreach (var file in Model.MovieFileLinks)
+                            {
+                                <a title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a>
+                            }
+                        </div>
+                    </div>
+                    @foreach (var torrent in Model.TorrentLinks)
+                    {
+                        <a class="col-lg-4" href="~/torrent/@torrent.Path">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
+                    }
+                    <a class="col-lg-4" condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl">A/V file via Mirror</a>
+                </row>
+                <row>
+                    <div class="col-md-2">
+                        <small condition="Model.GenreTags.Any()">
+                            Genre:<br />
+                            @foreach (var genre in Model.GenreTags)
+                            {
+                                <a href="/Movies-@genre.Code">@genre.DisplayName</a>
+                            }
+                            <br />
+                        </small>
+                        <small condition="Model.Tags.Any()">
+                            Tags:<br />
+                            @foreach (var tag in Model.Tags)
+                            {
+                                <a href="/Movies-@tag.Code">@tag.DisplayName</a><br />
+                            }
+                        </small>
+                        <small condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
+                            Emulator Version:<br />@Model.EmulatorVersion
+                        </small>
+                    </div>
+                </row>
+            </div>
+        </row>
 	</cardbody>
 </card>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -42,7 +42,7 @@
             <div class="pixelart-image float-left" condition="!string.IsNullOrWhiteSpace(Model.TierIconPath)">
                 <img src="/@Model.TierIconPath" />
             </div>
-            <h4 class="col px-2"><a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></a></h4>
+            <h4 class="col px-2 m-0"><a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></a></h4>
             <div class="float-right">
             @foreach (var flag in Model.Flags.Where(f => !string.IsNullOrWhiteSpace(f.IconPath)))
             {

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -2,7 +2,7 @@
 
 @inject IAwards Awards 
 @{
-	var publicationAwards = await Awards.ForPublication(Model.Id);
+    var publicationAwards = await Awards.ForPublication(Model.Id);
 }
 
 @functions {
@@ -38,15 +38,20 @@
 }
 <card class="border border-primary">
 	<cardheader class="bg-bgprimary">
-		<img class="pixelart-image" condition="!string.IsNullOrWhiteSpace(Model.TierIconPath)" src="/@Model.TierIconPath" /> <h4 class="m-0"><a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></a></h4>
-		<div class="pull-right">
-			@foreach (var flag in Model.Flags.Where(f => !string.IsNullOrWhiteSpace(f.IconPath)))
-			{
-				<a href="@flag.LinkPath">
-					<img class="pixelart-image" title="@flag.Name" alt="[@flag.Name]" src="/@flag.IconPath" />
-				</a>
-			}
-		</div>
+        <row>
+            <div class="pixelart-image float-left" condition="!string.IsNullOrWhiteSpace(Model.TierIconPath)">
+                <img src="/@Model.TierIconPath" />
+            </div>
+            <h4 class="col px-2"><a asp-page="View" asp-route-id="@Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></a></h4>
+            <div class="float-right">
+            @foreach (var flag in Model.Flags.Where(f => !string.IsNullOrWhiteSpace(f.IconPath)))
+            {
+                <a href="@flag.LinkPath">
+                    <img class="pixelart-image" title="@flag.Name" alt="[@flag.Name]" src="/@flag.IconPath" />
+                </a>
+            }
+            </div>
+        </row>
 	</cardheader>
     <cardbody class="px-3 py-0">
         <div condition="@Model.ObsoletedById.HasValue" class="col card-subtitle text-danger my-2">
@@ -73,6 +78,12 @@
                 <a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1">Download (@System.IO.Path.GetExtension(Model.MovieFileName))</a>
                 <br />
                 <a asp-page="/Submissions/View" asp-route-id="@Model.SubmissionId" class="btn btn-secondary btn-sm mt-1">Submission</a>
+                <a condition="@Model.TopicId > 0"
+                   asp-page="/Forum/Topics/Index"
+                   asp-route-id="@Model.TopicId"
+                   class="btn btn-secondary btn-sm mt-1">
+                    Discuss
+                </a>
                 <br />
                 <a permission="EditPublicationMetaData"
                    asp-page="Edit"
@@ -82,12 +93,6 @@
                    asp-page="/Publications/Catalog"
                    asp-route-id="@Model.Id"
                    class="btn btn-secondary btn-sm mt-1">Catalog</a>
-                <a condition="@Model.TopicId > 0"
-                   asp-page="/Forum/Topics/Index"
-                   asp-route-id="@Model.TopicId"
-                   class="btn btn-secondary btn-sm mt-1">
-                    Discuss
-                </a>
                 <a asp-page="/Games/PublicationHistory"
                    asp-route-id="@Model.GameId"
                    asp-route-highlight="@Model.Id"
@@ -135,16 +140,17 @@
             }
         </row>
         <row class="mb-2">
-            <div class="col-auto">
-                <small condition="Model.GenreTags.Any()">
-                    Genre:<br />
+            <div condition="Model.GenreTags.Any()" class="col-auto">
+                <small>
+                    Genres:<br />
                     @foreach (var genre in Model.GenreTags)
                     {
-                        <a href="/Movies-@genre.Code">@genre.DisplayName</a>
+                        <a href="/Movies-@genre.Code" class="ml-2">@genre.DisplayName</a><br />
                     }
-                    <br />
                 </small>
-                <small condition="Model.Tags.Any()">
+            </div>
+            <div condition="Model.Tags.Any()" class="col-auto">
+                <small>
                     Tags:<br />
                     @foreach (var tag in Model.Tags)
                     {
@@ -152,28 +158,31 @@
                     }
                 </small>
             </div>
-            <a class="col-lg-4" condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl">A/V file via Mirror</a>
             <div class="col-auto">
-                <div condition="Model.MovieFileLinks.Any()" class="col-lg-4">
-                    <div class="mt-2">
-                        @foreach (var file in Model.MovieFileLinks)
+                <small condition="!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl) || Model.TorrentLinks.Any()">
+                    A/V files:<br />
+                    <a condition="@(!string.IsNullOrWhiteSpace(Model.MirrorSiteUrl))" href="@Model.MirrorSiteUrl" class="ml-2">A/V file via Mirror<br /></a>
+                    <span condition="Model.TorrentLinks.Any()">
+                        @foreach (var torrent in Model.TorrentLinks)
                         {
-                            <a title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a>
+                            <a href="~/torrent/@torrent.Path" class="ml-2">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
+                            <br />
                         }
-                    </div>
-                </div>
-                <small condition="Model.TorrentLinks.Any()">
-                    Torrents:<br />
-                    @foreach (var torrent in Model.TorrentLinks)
-                    {
-                        <a href="~/torrent/@torrent.Path" class="ml-2">A/V file via BitTorrent @TorrentRemark(torrent.Path, torrent.Id)</a>
-                        <br />
-                    }
+                    </span>
                 </small>
             </div>
             <div class="col-auto">
                 <small condition="!string.IsNullOrWhiteSpace(Model.EmulatorVersion)">
                     Emulator Version:<br /><span class="ml-2">@Model.EmulatorVersion</span>
+                </small>
+            </div>
+            <div condition="Model.MovieFileLinks.Any()" class="col-auto">
+                <small>
+                    Additional Downloads:<br />
+                    @foreach (var file in Model.MovieFileLinks)
+                    {
+                        <a class="ml-2" title="@file.Path" asp-page="/Publications/View" asp-page-handler="DownloadAdditional" asp-route-fileId="@file.Id">(@file.Description)</a>
+                    }
                 </small>
             </div>
         </row>

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -57,7 +57,7 @@
                 <pub-link id="Model.ObsoletedById!.Value" class="btn btn-danger btn-sm">Obsoleting Movie</pub-link>
             </row>
         </div>
-        <row class="bg-bgsecondary py-3">
+        <row class="bg-bgsecondary py-3 mx-n3">
             <div class="col-auto mb-4 mb-md-0 mx-auto text-center text-md-left">
                 <div>
                     <img src="~/media/@Model.Screenshot.Path"

--- a/TASVideos/Pages/Shared/_MovieModule.cshtml
+++ b/TASVideos/Pages/Shared/_MovieModule.cshtml
@@ -68,7 +68,7 @@
                 </div>
                 @foreach (var url in Model.OnlineWatchingUrls)
                 {
-                    <a href="@url" class="btn btn-primary btn-sm mt-1">Watch</a>
+                    <a href="@url" class="btn btn-primary btn-sm mt-1" target="_blank">Watch</a>
                 }
                 <a asp-page="/Publications/View" asp-page-handler="Download" asp-route-id="@Model.Id" class="btn btn-primary btn-sm mt-1">Download (@System.IO.Path.GetExtension(Model.MovieFileName))</a>
                 <br />

--- a/TASVideos/wwwroot/css/bootstrap.scss
+++ b/TASVideos/wwwroot/css/bootstrap.scss
@@ -18,6 +18,8 @@ $theme-colors: (
 	"light": 		$light,
 	"muted": 		$muted,
 	"white": 		$white,
+	"bgprimary":    #acd,
+	"bgsecondary":  #cde,
 );
 
 @import "../lib/twitter-bootstrap/scss/root";

--- a/TASVideos/wwwroot/css/variables.scss
+++ b/TASVideos/wwwroot/css/variables.scss
@@ -4,7 +4,7 @@ $success: 	#28a745;
 $danger: 	#dc3545;
 $warning: 	#ffc107;
 $info: 		#c2d4fc;
-$dark: 		#343a40;
+$dark: 		#000000;
 $light: 	#f8f9fa;
 $muted: 	#6c757d;
 $white: 	#fff;

--- a/TASVideos/wwwroot/css/variables.scss
+++ b/TASVideos/wwwroot/css/variables.scss
@@ -1,5 +1,5 @@
-$primary: 	#6a37a0;
-$secondary: #9f76c0;
+$primary:   #105cb6;
+$secondary: #6a37a0;
 $success: 	#28a745;
 $danger: 	#dc3545;
 $warning: 	#ffc107;


### PR DESCRIPTION
This makes the publication page more readable. The page is automatically used for the movie lists, so those are changed as well.
The code also changes the frontpage featured movie design to reflect the change in design.
The title is now clickable and brings you to the publication page.

[Before image](https://user-images.githubusercontent.com/22375320/132132651-628ceb09-5ce8-4c4b-877d-eb6e95973b20.png)

After image:
![After image](https://user-images.githubusercontent.com/22375320/132132656-6c674893-1e38-412e-be1f-516e8eac5a71.png)
