### PR TITLE
MovieStatistics module

### DIFF
--- a/TASVideos.WikiEngine/WikiModules.cs
+++ b/TASVideos.WikiEngine/WikiModules.cs
@@ -31,6 +31,7 @@ namespace TASVideos.WikiEngine
 		public const string MoviesByAuthor = "moviesbyplayer";
 		public const string MoviesGameList = "moviesgamelist";
 		public const string MoviesList = "movieslist";
+		public const string MovieStatistics = "moviestatistics";
 		public const string MovieMaintenanceLog = "moviemaintlog";
 		public const string NoGameName = "nogamename";
 		public const string PlatformAuthorList = "platformtaserlists";

--- a/TASVideos/Pages/Shared/Components/MovieStatistics/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/MovieStatistics/Default.cshtml
@@ -1,0 +1,28 @@
+﻿@model MovieStatisticsModel
+<warning-alert condition="!string.IsNullOrEmpty(Model.ErrorMessage)">
+    @Model.ErrorMessage
+</warning-alert>
+
+<div>
+    @if (Model.MovieList.Count > 0)
+    {
+        <table>
+            <tr>
+                <th>@Model.FieldHeader</th>
+                <th>Movie</th>
+            </tr>
+
+            @foreach (var entry in Model.MovieList)
+            {
+                <tr>
+                    <td>
+                        @entry.DisplayValue
+                    </td>
+                    <td>
+                        <pub-link id="entry.Id">@entry.Title</pub-link>
+                    </td>
+                </tr>
+            }
+        </table>
+    }
+</div>

--- a/TASVideos/Pages/Shared/Components/MovieStatistics/General.cshtml
+++ b/TASVideos/Pages/Shared/Components/MovieStatistics/General.cshtml
@@ -1,0 +1,12 @@
+﻿@model MovieGeneralStatisticsModel
+
+<div>
+    <p>
+        <ul>
+            <li>Published movies: @Model.PublishedMovieCount</li>
+            <li>Total movies (including obsoleted): @Model.TotalMovieCount</li>
+            <li>Submitted movies: @Model.SubmissionCount</li>
+            <li>Published movie average rerecord count: @Model.AverageRerecordCount</li>
+        </ul>
+    </p>
+</div>

--- a/TASVideos/ViewComponents/Models/MovieGeneralStatisticsModel.cs
+++ b/TASVideos/ViewComponents/Models/MovieGeneralStatisticsModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using TASVideos.Common;
+using TASVideos.Data.Entity;
+
+namespace TASVideos.ViewComponents
+{
+	public class MovieGeneralStatisticsModel
+	{
+		public int PublishedMovieCount { get; init; }
+		public int TotalMovieCount { get; init; }
+		public int SubmissionCount { get; init; }
+		public int AverageRerecordCount { get; init; }
+	}
+}

--- a/TASVideos/ViewComponents/Models/MovieStatisticsModel.cs
+++ b/TASVideos/ViewComponents/Models/MovieStatisticsModel.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using TASVideos.Common;
+using TASVideos.Data.Entity;
+
+namespace TASVideos.ViewComponents
+{
+	public class MovieStatisticsModel
+	{
+		public string ErrorMessage { get; init; } = "";
+		public string FieldHeader { get; init; } = "";
+		public ICollection<MovieStatisticsEntry> MovieList { get; init; } = new List<MovieStatisticsEntry>();
+
+		public class MovieStatisticsEntry
+		{
+			public int Id { get; init; }
+			public string Title { get; init; } = "";
+			public virtual string DisplayValue => Id.ToString();
+			public virtual IComparable Comparable => Id;
+		}
+
+		public class MovieStatisticsIntEntry : MovieStatisticsEntry
+		{
+			public int IntValue { get; init; }
+			public override string DisplayValue => IntValue.ToString();
+			public override IComparable Comparable => IntValue;
+		}
+
+		public class MovieStatisticsFloatEntry : MovieStatisticsEntry
+		{
+			public float FloatValue { get; init; }
+			public override string DisplayValue => FloatValue.ToString();
+			public override IComparable Comparable => FloatValue;
+		}
+
+		public class MovieStatisticsTimeSpanEntry : MovieStatisticsEntry
+		{
+			public TimeSpan TimeSpanValue { get; init; }
+			public override string DisplayValue => TimeSpanValue.ToStringWithOptionalDaysAndHours();
+			public override IComparable Comparable => TimeSpanValue;
+		}
+	}
+}

--- a/TASVideos/ViewComponents/MovieStatistics.cs
+++ b/TASVideos/ViewComponents/MovieStatistics.cs
@@ -1,0 +1,302 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TASVideos.Data;
+using TASVideos.Data.Entity;
+using TASVideos.WikiEngine;
+
+namespace TASVideos.ViewComponents
+{
+	[WikiModule(WikiModules.MovieStatistics)]
+	public class MovieStatistics : ViewComponent
+	{
+		public enum MovieStatisticComparison
+		{
+			None,
+
+			// Movie data
+			Length,
+			Rerecords,
+			RerecordsPerLength,
+			DaysPublished,
+
+			// File data
+			EncodeLength,
+			EncodeSize,
+			EncodeRatio,
+			EncodeLengthRatio,
+			LongestEnding,
+
+			// Text data
+			DescriptionLength,
+			SubmissionDescriptionLength,
+
+			// Rating data
+			AverageRating,
+			EntertainmentRating,
+			TechnicalRating,
+			VoteCount
+		}
+
+		public readonly Dictionary<string, MovieStatisticComparison> ParameterList = new Dictionary<string, MovieStatisticComparison>
+		{
+			{ string.Empty, MovieStatisticComparison.None },
+			{ "length", MovieStatisticComparison.Length },
+			{ "filererecords", MovieStatisticComparison.Rerecords },
+			{ "rerecsPerLength", MovieStatisticComparison.RerecordsPerLength },
+			{ "daysPublished", MovieStatisticComparison.DaysPublished },
+			{ "alength", MovieStatisticComparison.EncodeLength },
+			{ "asize", MovieStatisticComparison.EncodeSize },
+			{ "encodeRatio", MovieStatisticComparison.EncodeRatio },
+			{ "alengthPerLength", MovieStatisticComparison.EncodeLengthRatio },
+			{ "alengthMinusLength", MovieStatisticComparison.LongestEnding },
+			{ "desclen", MovieStatisticComparison.DescriptionLength },
+			{ "udesclen", MovieStatisticComparison.SubmissionDescriptionLength },
+			{ "averageRating", MovieStatisticComparison.AverageRating },
+			{ "entertainmentRating", MovieStatisticComparison.EntertainmentRating },
+			{ "qualityRating", MovieStatisticComparison.TechnicalRating },
+			{ "numberOfVotes", MovieStatisticComparison.VoteCount },
+		};
+
+		private readonly ApplicationDbContext _db;
+
+		public MovieStatistics(ApplicationDbContext db)
+		{
+			_db = db;
+		}
+
+		public async Task<IViewComponentResult> InvokeAsync(string? comp, int? minAge, int? minVotes, int? top)
+		{
+			string comparisonParameter = comp ?? string.Empty;
+			int count = top ?? 10;
+
+			// these are only uesd for rating statistics
+			int minimumVotes = minVotes ?? 1;
+			int minimumAge = minAge ?? 0;
+			DateTime minimumAgeTime = DateTime.Now.AddDays(-minimumAge);
+
+			bool reverse = comparisonParameter.StartsWith("-");
+			if (reverse)
+			{
+				comparisonParameter = comparisonParameter.Substring(1);
+			}
+
+			var comparisonMetric = ParameterList.GetValueOrDefault(comparisonParameter);
+			string fieldHeader = "";
+
+			List<MovieStatisticsModel.MovieStatisticsEntry> movieList = new List<MovieStatisticsModel.MovieStatisticsEntry>();
+
+			switch (comparisonMetric)
+			{
+				case MovieStatisticComparison.None:
+					var generalModel = new MovieGeneralStatisticsModel()
+					{
+						PublishedMovieCount = await _db.Publications.ThatAreCurrent().CountAsync(),
+						TotalMovieCount = await _db.Publications.CountAsync(),
+						SubmissionCount = await _db.Submissions.CountAsync(),
+						AverageRerecordCount = (int)await _db.Publications.AverageAsync(p => p.RerecordCount),
+					};
+					return View("General", generalModel);
+
+				default:
+					// debugging: sort by publication id
+					fieldHeader = "Publication";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Select(p => new MovieStatisticsModel.MovieStatisticsEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.Length:
+					fieldHeader = "Length";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.System != null && p.SystemFrameRate != null)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsTimeSpanEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+
+							// the hackiest of workarounds but just calling Time() makes it explode for hardly fathomable reasons
+							TimeSpanValue = TimeSpan.FromMilliseconds(Math.Round(p.Frames / p.SystemFrameRate.FrameRate * 100, MidpointRounding.AwayFromZero) * 10)
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.Rerecords:
+					fieldHeader = "Rerecords";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.RerecordCount > 0)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsIntEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+							IntValue = p.RerecordCount
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.RerecordsPerLength:
+					fieldHeader = "Rerecords per frame";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.RerecordCount > 0)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsFloatEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+
+							// this should use time instead of frames, but time is a massive pain to properly fetch currently
+							FloatValue = (float)p.RerecordCount / p.Frames
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.DaysPublished:
+					fieldHeader = "Days";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsIntEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+							IntValue = (int)Math.Round((DateTime.Now - p.CreateTimestamp).TotalDays)
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.EncodeLength:
+				case MovieStatisticComparison.EncodeSize:
+				case MovieStatisticComparison.EncodeRatio:
+				case MovieStatisticComparison.EncodeLengthRatio:
+				case MovieStatisticComparison.LongestEnding:
+
+					// currently unable to fetch encode data
+					return View(
+						new MovieStatisticsModel()
+						{
+							ErrorMessage = "Could not display statistics for given parameter: " + comparisonParameter
+						});
+
+				case MovieStatisticComparison.DescriptionLength:
+					fieldHeader = "Characters";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.WikiContent != null)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsIntEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+							IntValue = p.WikiContent.Markup.Length
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.SubmissionDescriptionLength:
+					fieldHeader = "Characters";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.Submission != null && p.Submission.WikiContent != null)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsIntEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+							IntValue = p.Submission.WikiContent.Markup.Length
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.AverageRating:
+					fieldHeader = "Rating";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.PublicationRatings != null && p.PublicationRatings.Count >= minimumVotes)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsFloatEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+							FloatValue =
+							(float)Math.Round(
+								((float)p.PublicationRatings.Where(r => r.Type == PublicationRatingType.Entertainment).Average(r => r.Value) * (2f / 3f))
+							+ ((float)p.PublicationRatings.Where(r => r.Type == PublicationRatingType.TechQuality).Average(r => r.Value) * (1f / 3f)), 2)
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.EntertainmentRating:
+					fieldHeader = "Entertainment rating";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.PublicationRatings != null && p.PublicationRatings.Count >= minimumVotes)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsFloatEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+							FloatValue =
+							(float)Math.Round(p.PublicationRatings.Where(r => r.Type == PublicationRatingType.Entertainment).Average(r => r.Value), 2)
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.TechnicalRating:
+					fieldHeader = "Technical rating";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.PublicationRatings != null && p.PublicationRatings.Count >= minVotes)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsFloatEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+							FloatValue =
+							(float)Math.Round(p.PublicationRatings.Where(r => r.Type == PublicationRatingType.TechQuality).Average(r => r.Value), 2)
+						})
+						.ToListAsync();
+					break;
+
+				case MovieStatisticComparison.VoteCount:
+					fieldHeader = "Ratings";
+					movieList = await _db.Publications
+						.ThatAreCurrent()
+						.Where(p => p.PublicationRatings != null && p.CreateTimestamp <= minimumAgeTime)
+						.Select(p =>
+						(MovieStatisticsModel.MovieStatisticsEntry)new MovieStatisticsModel.MovieStatisticsFloatEntry
+						{
+							Id = p.Id,
+							Title = p.Title,
+							FloatValue = p.PublicationRatings.Count / 2f
+						})
+						.ToListAsync();
+					break;
+			}
+
+			var orderedList = reverse
+							? movieList.OrderByDescending(p => p.Comparable).Take(count).ToList()
+							: movieList.OrderBy(p => p.Comparable).Take(count).ToList();
+
+			var model = new MovieStatisticsModel
+			{
+				MovieList = orderedList,
+				FieldHeader = fieldHeader
+			};
+
+			return View("Default", model);
+		}
+	}
+}

--- a/TASVideos/ViewComponents/MovieStatistics.cs
+++ b/TASVideos/ViewComponents/MovieStatistics.cs
@@ -43,22 +43,22 @@ namespace TASVideos.ViewComponents
 
 		public readonly Dictionary<string, MovieStatisticComparison> ParameterList = new Dictionary<string, MovieStatisticComparison>
 		{
-			{ string.Empty, MovieStatisticComparison.None },
-			{ "length", MovieStatisticComparison.Length },
-			{ "filererecords", MovieStatisticComparison.Rerecords },
-			{ "rerecsPerLength", MovieStatisticComparison.RerecordsPerLength },
-			{ "daysPublished", MovieStatisticComparison.DaysPublished },
-			{ "alength", MovieStatisticComparison.EncodeLength },
-			{ "asize", MovieStatisticComparison.EncodeSize },
-			{ "encodeRatio", MovieStatisticComparison.EncodeRatio },
-			{ "alengthPerLength", MovieStatisticComparison.EncodeLengthRatio },
-			{ "alengthMinusLength", MovieStatisticComparison.LongestEnding },
-			{ "desclen", MovieStatisticComparison.DescriptionLength },
-			{ "udesclen", MovieStatisticComparison.SubmissionDescriptionLength },
-			{ "averageRating", MovieStatisticComparison.AverageRating },
-			{ "entertainmentRating", MovieStatisticComparison.EntertainmentRating },
-			{ "qualityRating", MovieStatisticComparison.TechnicalRating },
-			{ "numberOfVotes", MovieStatisticComparison.VoteCount },
+			[string.Empty] = MovieStatisticComparison.None,
+			["length"] = MovieStatisticComparison.Length,
+			["filererecords"] = MovieStatisticComparison.Rerecords,
+			["rerecsPerLength"] = MovieStatisticComparison.RerecordsPerLength,
+			["daysPublished"] = MovieStatisticComparison.DaysPublished,
+			["alength"] = MovieStatisticComparison.EncodeLength,
+			["asize"] = MovieStatisticComparison.EncodeSize,
+			["encodeRatio"] = MovieStatisticComparison.EncodeRatio,
+			["alengthPerLength"] = MovieStatisticComparison.EncodeLengthRatio,
+			["alengthMinusLength"] = MovieStatisticComparison.LongestEnding,
+			["desclen"] = MovieStatisticComparison.DescriptionLength,
+			["udesclen"] = MovieStatisticComparison.SubmissionDescriptionLength,
+			["averageRating"] = MovieStatisticComparison.AverageRating,
+			["entertainmentRating"] = MovieStatisticComparison.EntertainmentRating,
+			["qualityRating"] = MovieStatisticComparison.TechnicalRating,
+			["numberOfVotes"] = MovieStatisticComparison.VoteCount
 		};
 
 		private readonly ApplicationDbContext _db;
@@ -126,7 +126,7 @@ namespace TASVideos.ViewComponents
 							Title = p.Title,
 
 							// the hackiest of workarounds but just calling Time() makes it explode for hardly fathomable reasons
-							TimeSpanValue = TimeSpan.FromMilliseconds(Math.Round(p.Frames / p.SystemFrameRate.FrameRate * 100, MidpointRounding.AwayFromZero) * 10)
+							TimeSpanValue = TimeSpan.FromMilliseconds(Math.Round(p.Frames / p.SystemFrameRate!.FrameRate * 100, MidpointRounding.AwayFromZero) * 10)
 						})
 						.ToListAsync();
 					break;
@@ -200,7 +200,7 @@ namespace TASVideos.ViewComponents
 						{
 							Id = p.Id,
 							Title = p.Title,
-							IntValue = p.WikiContent.Markup.Length
+							IntValue = p.WikiContent!.Markup.Length
 						})
 						.ToListAsync();
 					break;
@@ -215,7 +215,7 @@ namespace TASVideos.ViewComponents
 						{
 							Id = p.Id,
 							Title = p.Title,
-							IntValue = p.Submission.WikiContent.Markup.Length
+							IntValue = p.Submission!.WikiContent!.Markup.Length
 						})
 						.ToListAsync();
 					break;


### PR DESCRIPTION
MovieStatistics module, as used in /MovieStatistics and related subpages. Compare to the original here: http://tasvideos.org/MovieStatistics.html

This is an enormous beast of a module, and due to various intricacies in fetching the required values for every trackable stat, the code isn't the prettiest - but this is the best that I have been able to come up with, so far. I expect that some ways to clean some of the code up will be found in review.

Because of the nature of the reworked database, there are some regressions, in terms of data that is difficult or impossible to gather. This includes data related to encode statistics (filesize/length etc.), which I found no way to fetch. There are also some difficulties and workarounds in regards to retrieving the movie time.

Partial screenshots for demonstration:
![image](https://user-images.githubusercontent.com/5488449/132987812-ee3b3c99-f092-4606-a6d7-220cb5de037d.png)
![image](https://user-images.githubusercontent.com/5488449/132987824-5c3fcb5c-efe7-4377-a7cd-ab19f80ea5b1.png)
