### PR TITLE
Add last post link and profile links to subforum topic entries

### DIFF
--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -38,12 +38,12 @@
 					</a>
 				</td>
 				<td>@Math.Max(0, topic.PostCount - 1)</td> @*Imported Submission Topics will have no replies and no original post*@
-				<td> <profile-link username="@topic.CreateUserName">@topic.CreateUserName</profile-link></td>
+				<td> <profile-link username="@topic.CreateUserName"></profile-link></td>
                 <td>
                     @if (topic.LastPost != null)
                     {
                         <timezone-convert asp-for="@topic.LastPostDateTime" /> <br />
-                        <profile-link username="@topic.LastPostUserName">@topic.LastPostUserName</profile-link>
+						<profile-link username="@topic.LastPostUserName"></profile-link>
                         <a class="fa fa-arrow-circle-right" href="/Forum/p/@topic.LastPostId#@topic.LastPostId"/>
                     }
                     </td>

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -38,8 +38,15 @@
 					</a>
 				</td>
 				<td>@Math.Max(0, topic.PostCount - 1)</td> @*Imported Submission Topics will have no replies and no original post*@
-				<td>@topic.CreateUserName</td>
-				<td><timezone-convert asp-for="@topic.LastPostDateTime" /></td>
+				<td> <profile-link username="@topic.CreateUserName">@topic.CreateUserName</profile-link></td>
+                <td>
+                    @if (topic.LastPost != null)
+                    {
+                        <timezone-convert asp-for="@topic.LastPostDateTime" /> <br />
+                        <profile-link username="@topic.LastPostUserName">@topic.LastPostUserName</profile-link>
+                        <a class="fa fa-arrow-circle-right" href="/Forum/p/@topic.LastPostId#@topic.LastPostId"/>
+                    }
+                    </td>
 			</tr>
 		}
 	</table>

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -62,7 +62,7 @@ namespace TASVideos.Pages.Forum.Subforum
 					CreateTimestamp = ft.CreateTimestamp,
 					Type = ft.Type,
 					PostCount = ft.ForumPosts.Count,
-					LastPost = ft.ForumPosts.Max(fp => (DateTime?)fp.CreateTimestamp)
+					LastPost = ft.ForumPosts.OrderBy(fp => fp.CreateTimestamp).Last()
 				})
 				.OrderByDescending(ft => ft.Type == ForumTopicType.Sticky)
 				.ThenByDescending(ft => ft.Type == ForumTopicType.Announcement)

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -62,7 +62,7 @@ namespace TASVideos.Pages.Forum.Subforum
 					CreateTimestamp = ft.CreateTimestamp,
 					Type = ft.Type,
 					PostCount = ft.ForumPosts.Count,
-					LastPost = ft.ForumPosts.OrderBy(fp => fp.CreateTimestamp).Last()
+					LastPost = ft.ForumPosts.OrderByDescending(fp => fp.CreateTimestamp).First()
 				})
 				.OrderByDescending(ft => ft.Type == ForumTopicType.Sticky)
 				.ThenByDescending(ft => ft.Type == ForumTopicType.Announcement)

--- a/TASVideos/Pages/Forum/Subforum/Models/ForumDisplayModel.cs
+++ b/TASVideos/Pages/Forum/Subforum/Models/ForumDisplayModel.cs
@@ -28,8 +28,10 @@ namespace TASVideos.Pages.Forum.Subforum.Models
 
 			public ForumTopicType Type { get; set; }
 
-			public DateTime? LastPost { get; set; }
-			public DateTime LastPostDateTime => LastPost ?? DateTime.UtcNow; // This will never actually be null, EF just requires a nullable DateTime for .Max() operations
+			public ForumPost? LastPost { get; set; }
+			public DateTime LastPostDateTime => LastPost?.CreateTimestamp ?? DateTime.UtcNow; // This will never actually be null, EF just requires a nullable DateTime for .Max() operations
+			public int? LastPostId => LastPost?.Id ?? 0;
+			public string? LastPostUserName => LastPost?.CreateUserName ?? string.Empty;
 		}
 	}
 }


### PR DESCRIPTION
Fixes regressions compared to the original forum. Profile links help finding user information, and latest post link icon helps with forum browsing in general.

Old:

![image](https://user-images.githubusercontent.com/5488449/132995639-ab3d9de9-b49d-45a3-a88f-cec6795c97e1.png)

New:

![image](https://user-images.githubusercontent.com/5488449/132995643-eea4c778-e4a7-4ee6-866a-62cb6079a5cb.png)

Old forum for comparison:

![image](https://user-images.githubusercontent.com/5488449/132995682-254dfcb0-bd14-4389-81a5-737331e89259.png)
