### PR TITLE
Use WebOptimizer's TagHelpers and Fix Cache

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -6,7 +6,7 @@
 	<title>@(ViewData["Title"] != null ? ViewData["Title"] + " - " : "")TASVideos</title>
 
 	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous" />
 	<link rel="stylesheet" href="/css/site.css" />
 	<link rel="stylesheet" id="style-dark-initial" href="/css/darkmode-initial.css" />
 	<link rel="stylesheet" href="~/lib/font-awesome/css/font-awesome.css" />

--- a/TASVideos/Pages/_ViewImports.cshtml
+++ b/TASVideos/Pages/_ViewImports.cshtml
@@ -1,11 +1,12 @@
 @namespace TASVideos.Pages
 @using Microsoft.AspNetCore.Identity
 @using TASVideos
-@using TASVideos.Common 
+@using TASVideos.Common
 @using TASVideos.Data
 @using TASVideos.Data.Entity
 @using TASVideos.Extensions
 @using TASVideos.Core.Services
 @using TASVideos.ViewComponents
 @addTagHelper TASVideos.TagHelpers.*, TASVideos
+@addTagHelper *, WebOptimizer.Core
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/TASVideos/appsettings.Demo.json
+++ b/TASVideos/appsettings.Demo.json
@@ -22,9 +22,13 @@
         "Args": {
           "path": "/home/tasvideos/logs/applogs.json",
           "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog",
-          "rollingInterval":  "Day"
+          "rollingInterval": "Day"
         }
       }
     ]
+  },
+  "webOptimizer": {
+    "enableCaching": false,
+    "enableTagHelperBundling": false
   }
 }

--- a/TASVideos/appsettings.Development.json
+++ b/TASVideos/appsettings.Development.json
@@ -31,5 +31,9 @@
         }
       }
     ]
+  },
+  "webOptimizer": {
+    "enableCaching": false,
+    "enableTagHelperBundling": false
   }
 }


### PR DESCRIPTION
Fixes #424 

Allows WebOptimizer to control cache headers for its bundles and adjust cache behavior between dev and prod. Prod assets will now have query strings which will be updated on any changes to live assets to force the new assets to be used. Local and demo site CSS/JS bundles will have a no-cache header so they are never cached by the end user.