### PR TITLE
Userfiles: Summing and displaying compressed instead of uncompressed filesizes

### DIFF
--- a/TASVideos/MappingProfile.cs
+++ b/TASVideos/MappingProfile.cs
@@ -70,7 +70,8 @@ namespace TASVideos
 
 			CreateMap<UserFile, UserFileModel>()
 				.ForMember(dest => dest.Author, opt => opt.MapFrom(src => src.Author!.UserName))
-				.ForMember(dest => dest.FileSize, opt => opt.MapFrom(src => src.LogicalLength))
+				.ForMember(dest => dest.FileSizeUncompressed, opt => opt.MapFrom(src => src.LogicalLength))
+				.ForMember(dest => dest.FileSizeCompressed, opt => opt.MapFrom(src => src.PhysicalLength))
 				.ForMember(dest => dest.GameId, opt => opt.MapFrom(src => src.Game != null ? src.Game.Id : (int?)null))
 				.ForMember(dest => dest.GameName, opt => opt.MapFrom(src => src.Game != null ? src.Game.DisplayName : ""))
 				.ForMember(dest => dest.GameSystem, opt => opt.MapFrom(src => src.Game != null ? src.Game.System!.Code : ""))

--- a/TASVideos/Models/UserFileModel.cs
+++ b/TASVideos/Models/UserFileModel.cs
@@ -17,7 +17,8 @@ namespace TASVideos.Models
 		public int Downloads { get; set; }
 		public bool Hidden { get; set; }
 		public string? FileName { get; set; }
-		public int FileSize { get; set; }
+		public int FileSizeUncompressed { get; set; }
+		public int FileSizeCompressed { get; set; }
 		public int? GameId { get; set; }
 		public string? GameName { get; set; }
 		public string? GameSystem { get; set; }

--- a/TASVideos/Pages/Profile/UserFiles.cshtml
+++ b/TASVideos/Pages/Profile/UserFiles.cshtml
@@ -4,7 +4,7 @@
 @{
 	ViewData["Title"] = "My Files";
 	ViewData.AddActivePage(ProfileNavPages.UserFiles);
-	var used = Model.Files.Sum(f => f.FileSize);
+	var used = Model.Files.Sum(f => f.FileSizeCompressed);
 }
 
 <fullrow>

--- a/TASVideos/Pages/Shared/_UserFileInfo.cshtml
+++ b/TASVideos/Pages/Shared/_UserFileInfo.cshtml
@@ -121,7 +121,7 @@
 			<hr />
 		</div>
 		<a asp-page="/UserFiles/Info" asp-page-handler="Download" asp-route-id="@Model.Id" class="card-link">
-			Download (@Model.FileSize.ToSizeString())
+			Download (@Model.FileSizeUncompressed.ToSizeString())
 		</a>
 
 		<a asp-page="/UserFiles/Info" asp-route-id="@Model.Id" class="card-link">

--- a/TASVideos/Pages/UserFiles/Upload.cshtml.cs
+++ b/TASVideos/Pages/UserFiles/Upload.cshtml.cs
@@ -158,7 +158,7 @@ namespace TASVideos.Pages.UserFiles
 			var userId = User.GetUserId();
 			StorageUsed = await _db.UserFiles
 				.Where(uf => uf.AuthorId == userId)
-				.SumAsync(uf => uf.LogicalLength);
+				.SumAsync(uf => uf.PhysicalLength);
 
 			AvailableSystems = UiDefaults.DefaultEntry.Concat(await _db.GameSystems
 				.Select(s => new SelectListItem


### PR DESCRIPTION
Since users aren't allowed to compress files on their own, it makes no sense to sum the uncompressed files if the server compresses them.

This is related to #411 but there are more issues that need to be looked at in there.