### PR TITLE
Refactors dark mode button toggle into a dropdown for the header

### DIFF
--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="utf-8" />
@@ -103,7 +103,6 @@
 	<footer class="mb-3">
 		<row class="justify-content-start align-items-center">
 			<p class="col-auto my-auto">&copy; @DateTime.UtcNow.Year - TASVideos <a href="https://github.com/adelikat/tasvideos/commit/@ViewData["VersionSha"]">v@(ViewData["Version"])</a></p>
-			<button class="btn btn-secondary btn-sm col-auto" id="ToggleDarkMode" onclick="toggleDarkMode()"><i class="fa fa-moon-o"></i> Toggle Dark Mode</button>
 		</row>
 	</footer>
 </div>

--- a/TASVideos/Pages/Shared/_NavBarPartial.cshtml
+++ b/TASVideos/Pages/Shared/_NavBarPartial.cshtml
@@ -45,4 +45,10 @@
 		<a class="dropdown-item" href="/System">System Pages</a>
 		<a permission="SeeDeletedWikiPages" asp-page="/Wiki/DeletedPages" class="dropdown-item">Deleted Pages</a>
 	</nav-dropdown>
+	<nav-dropdown activate='<i class="fa fa-adjust"></i>'>
+		<button class="dropdown-item" onclick="forceDarkMode()"><i class="fa fa-moon-o"></i> Dark</button>
+		<button class="dropdown-item" onclick="forceLightMode()"><i class="fa fa-sun-o"></i> Light</button>
+		<button class="dropdown-item" onclick="autoDarkMode()">Auto</button>
+	</nav-dropdown>
+	
 </navbar>

--- a/TASVideos/TagHelpers/NavbarTagHelpers.cs
+++ b/TASVideos/TagHelpers/NavbarTagHelpers.cs
@@ -53,7 +53,7 @@ namespace TASVideos.TagHelpers
 			}
 
 			output.Content.SetHtmlContent(
-				$"<a href='#' class='nav-link dropdown-toggle' data-bs-toggle='dropdown'>{Text(Name ?? "")}<span class='caret'></span></a>");
+				$"<a href='#' class='nav-link dropdown-toggle' data-bs-toggle='dropdown'>{Name ?? ""}<span class='caret'></span></a>");
 
 			output.Content.AppendHtml($"<div class='dropdown-menu'>{content}</div>");
 		}

--- a/TASVideos/wwwroot/js/site.js
+++ b/TASVideos/wwwroot/js/site.js
@@ -88,38 +88,54 @@ NodeList.prototype.toArray = function () {
 	return Array.prototype.slice.call(this);
 };
 
-function loadDarkMode() {
+function forceDarkMode() {
+	removeAutoDarkMode();
+
 	var newElement = document.createElement('link');
 	newElement.rel = "stylesheet";
 	newElement.id = "style-dark";
 	newElement.href = "/css/darkmode.css";
 	document.head.appendChild(newElement);
+
+	localStorage.setItem("style-dark", "true");
 }
 
-function toggleDarkMode() {
+function forceLightMode() {
+	removeForcedDarkMode();
+	removeAutoDarkMode();
+
+	localStorage.setItem("style-dark", "false");
+}
+
+function autoDarkMode () {
+	removeForcedDarkMode();
+
+	var newElement = document.createElement('link');
+	newElement.rel = "stylesheet";
+	newElement.id = "style-dark-initial";
+	newElement.href = "/css/darkmode-initial.css";
+	document.head.appendChild(newElement);
+
+	localStorage.removeItem("style-dark");
+}
+
+function removeForcedDarkMode() {
+	let DarkModeStylesheet = document.getElementById("style-dark");
+	if (DarkModeStylesheet) {
+		DarkModeStylesheet.parentElement.removeChild(DarkModeStylesheet);
+	}
+}
+
+function removeAutoDarkMode () {
 	let initialDarkModeStylesheet = document.getElementById("style-dark-initial");
 	if (initialDarkModeStylesheet) {
 		initialDarkModeStylesheet.parentElement.removeChild(initialDarkModeStylesheet);
-		let userHasSystemDarkTheme = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-		if (!userHasSystemDarkTheme) {
-			loadDarkMode();
-		}
-		localStorage.setItem("style-dark", !userHasSystemDarkTheme);
-	} else {
-		let darkModeStylesheet = document.getElementById("style-dark");
-		if (darkModeStylesheet) {
-			darkModeStylesheet.parentElement.removeChild(darkModeStylesheet);
-		} else {
-			loadDarkMode();
-		}
-		localStorage.setItem("style-dark", !darkModeStylesheet);
 	}
 }
 
 if (localStorage.getItem("style-dark") !== null) {
-	let initialDarkModeStylesheet = document.getElementById("style-dark-initial");
-	initialDarkModeStylesheet.parentElement.removeChild(initialDarkModeStylesheet);
+	removeAutoDarkMode();
 	if (localStorage.getItem("style-dark") === "true") {
-		loadDarkMode();
+		forceDarkMode();
 	}
 }


### PR DESCRIPTION
Uses fa-adjust icon to denote a dropdown for dark mode, and adds the ability to revert to the default "auto" mode.