### PR TITLE
[COOL] Adding a reordering for the 6 subforum blocks in mobile view

### DIFF
--- a/TASVideos/Pages/Forum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Index.cshtml
@@ -31,7 +31,7 @@
 	</div>
 	<div class="d-md-none">
 		@* ReSharper disable once UnusedVariable *@
-		@foreach (var cat in Model.Categories.OrderBy(c=>(c.Ordinal-7)%27)) // please don't ban me
+		@foreach (var cat in Model.Categories.OrderBy(c => (c.Ordinal - 7) % 27)) // please don't ban me
 		{
 			<partial name="_Category" model="cat" />
 		}

--- a/TASVideos/Pages/Forum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Index.cshtml
@@ -15,18 +15,25 @@
 	</div>
 </fullrow>
 <row>
-	<div class="col-md-6">
+	<div class="d-none d-md-block col-md-6">
 		@* ReSharper disable once UnusedVariable *@
 		@foreach (var cat in Model.Categories.OrderBy(c => c.Ordinal).FirstHalf())
 		{
-		<partial name="_Category" model="cat" />
+			<partial name="_Category" model="cat" />
 		}
 	</div>
-	<div class="col-md-6">
+	<div class="d-none d-md-block col-md-6">
 		@* ReSharper disable once UnusedVariable *@
 		@foreach (var cat in Model.Categories.OrderBy(c => c.Ordinal).SecondHalf())
 		{
-		<partial name="_Category" model="cat" />
+			<partial name="_Category" model="cat" />
+		}
+	</div>
+	<div class="d-md-none">
+		@* ReSharper disable once UnusedVariable *@
+		@foreach (var cat in Model.Categories.OrderBy(c=>(c.Ordinal-7)%27)) // please don't ban me
+		{
+			<partial name="_Category" model="cat" />
 		}
 	</div>
 </row>


### PR DESCRIPTION
As mentioned, this adds a reordering for the 6 subforum blocks in mobile view.
It uses mathematics to add a reordering for the 6 subforum blocks in mobile view.
The old order is this:
General | Games | Other | Completed movies | Emulators | Non English
The new order is this:
General | Completed movies | Games | Emulators | Other | Non English

It works.