### PR TITLE
Adding Topic Title Editing

### DIFF
--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml
@@ -15,7 +15,7 @@
 				<div class="col-8 pt-0 pb-0">
 					<small>
 						Posted: <timezone-convert asp-for="@Model.Post.CreateTimestamp" /> 
-						<span condition="!string.IsNullOrWhiteSpace(Model.Post.Subject)">Post subject: @Model.Post.Subject</span>
+						<span condition="!Model.Post.IsFirstPost && !string.IsNullOrWhiteSpace(Model.Post.Subject)">Post subject: @Model.Post.Subject</span>
 					</small>
 				</div>
 			</row>
@@ -27,15 +27,18 @@
 </div>
 <hr />
 <form method="post">
-	<input type="hidden" asp-for="Post.TopicId" />
-	<input type="hidden" asp-for="Post.TopicTitle" />
 	<input type="hidden" asp-for="Post.EnableBbCode" />
 	<input type="hidden" asp-for="Post.EnableHtml" />
 	<row>
-		<column md="6">
+		<column condition="!Model.Post.IsFirstPost" md="6">
 			<label asp-for="Post.Subject" class="form-control-label"></label>
 			<input type="text" asp-for="Post.Subject" class="form-control" autocomplete="off" />
 			<span asp-validation-for="Post.Subject" class="text-danger"></span>
+		</column>
+		<column condition="Model.Post.IsFirstPost" md="6">
+			<label asp-for="Post.TopicTitle" class="form-control-label"></label>
+			<input type="text" asp-for="Post.TopicTitle" class="form-control" autocomplete="off" />
+			<span asp-validation-for="Post.TopicTitle" class="text-danger"></span>
 		</column>
 		<column md="6">
 			<label asp-for="Post.Mood" class="form-control-label"></label>

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -192,21 +192,5 @@ namespace TASVideos.Pages.Forum.Posts
 				? BasePageRedirect("/Forum/Subforum/Index", new { id = post.Topic!.ForumId })
 				: BasePageRedirect("/Forum/Topics/Index", new { id = post.TopicId });
 		}
-
-		private async Task<bool> CanEdit(ForumPost post, int userId)
-		{
-			if (post.PosterId != userId)
-			{
-				return false;
-			}
-
-			var lastPostId = await _db.ForumPosts
-				.ForTopic(post.TopicId ?? 0)
-				.ByMostRecent()
-				.Select(p => p.Id)
-				.FirstAsync();
-
-			return post.Id == lastPostId;
-		}
 	}
 }

--- a/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Edit.cshtml.cs
@@ -60,13 +60,13 @@ namespace TASVideos.Pages.Forum.Posts
 				return NotFound();
 			}
 
-			var lastPostId = (await _db.ForumPosts
+			var firstPostId = (await _db.ForumPosts
 				.ForTopic(Post.TopicId)
-				.ByMostRecent()
+				.OldestToNewest()
 				.FirstAsync())
 				.Id;
 
-			Post.IsLastPost = Id == lastPostId;
+			Post.IsFirstPost = Id == firstPostId;
 
 			if (!User.Has(PermissionTo.EditForumPosts)
 				&& Post.PosterId != User.GetUserId())
@@ -97,12 +97,24 @@ namespace TASVideos.Pages.Forum.Posts
 				return NotFound();
 			}
 
-			if (!User.Has(PermissionTo.EditForumPosts))
+			if (!User.Has(PermissionTo.EditForumPosts)
+				&& forumPost.PosterId != User.GetUserId())
 			{
-				if (!await CanEdit(forumPost, User.GetUserId()))
+				ModelState.AddModelError("", "Unable to edit post.");
+				return Page();
+			}
+
+
+			if (!string.IsNullOrWhiteSpace(Post.TopicTitle))
+			{
+				var firstPostId = (await _db.ForumPosts
+					.ForTopic(forumPost.Topic!.Id)
+					.OldestToNewest()
+					.FirstAsync())
+					.Id;
+				if (Id == firstPostId)
 				{
-					ModelState.AddModelError("", "Unable to edit post. It is no longer the latest post.");
-					return Page();
+					forumPost.Topic!.Title = Post.TopicTitle;
 				}
 			}
 

--- a/TASVideos/Pages/Forum/Posts/Models/ForumPostEditModel.cs
+++ b/TASVideos/Pages/Forum/Posts/Models/ForumPostEditModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 using TASVideos.Data.Entity.Forum;
@@ -15,6 +16,9 @@ namespace TASVideos.Pages.Forum.Posts.Models
 		public bool EnableHtml { get; set; }
 
 		public int TopicId { get; set; }
+
+		[DisplayName("Topic Title")]
+		[StringLength(500)]
 		public string TopicTitle { get; set; } = "";
 
 		[StringLength(500)]
@@ -23,7 +27,7 @@ namespace TASVideos.Pages.Forum.Posts.Models
 		[Required]
 		public string Text { get; set; } = "";
 
-		public bool IsLastPost { get; set; }
+		public bool IsFirstPost { get; set; }
 
 		public ForumPostMood Mood { get; set; } = ForumPostMood.Normal;
 	}


### PR DESCRIPTION
This adds back the functionality of editing the title of a topic.
It works like this:
If the edited post is the first one in the thread + a topic title is set -> it's being replaced.
For the user, the actual edit page checks if it's the first one and shows a Title Topic instead of a Subject text field.