### PR TITLE
Header and title adjustments

### DIFF
--- a/TASVideos/Extensions/EntityExtensions.cs
+++ b/TASVideos/Extensions/EntityExtensions.cs
@@ -95,15 +95,5 @@ namespace TASVideos.Extensions
 					IntendedTier = s.IntendedTier != null ? s.IntendedTier.Name : null
 				});
 		}
-
-		public static string ToTitleHtml(this ForumTopicType type, string title)
-		{
-			return type switch
-			{
-				ForumTopicType.Sticky => "<b>Sticky: </b> " + title,
-				ForumTopicType.Announcement => "<b>Announcement: </b> " + title,
-				_ => title
-			};
-		}
 	}
 }

--- a/TASVideos/Pages/Forum/Edit.cshtml
+++ b/TASVideos/Pages/Forum/Edit.cshtml
@@ -3,7 +3,6 @@
 @{
 	ViewData["Title"] = $"TASVideos Forum Category {Model.Category.Title}";
 }
-<partial Name="_ForumHeader" />
 <form method="post">
 	<row>
 		<div class="col-lg-6">

--- a/TASVideos/Pages/Forum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@page
 @model IndexModel
 @{
-	ViewData["Title"] = "TASVideos Forums";
+	ViewData["Title"] = "Forum";
 }
 <partial Name="_ForumHeader" />
 <fullrow class="pb-2 pt-2">

--- a/TASVideos/Pages/Forum/NotFound.cshtml
+++ b/TASVideos/Pages/Forum/NotFound.cshtml
@@ -1,4 +1,7 @@
 ﻿@page
+@{
+	ViewData["Title"] = $"Not Found";
+}
 <partial Name="_ForumHeader" />
-<a asp-page="/Forum">Forum Index</a>
+<h4><a asp-page="Index">Forum Index</a></h4>
 <warning-alert>The topic or post you requested does not exist</warning-alert>

--- a/TASVideos/Pages/Forum/Posts/New.cshtml
+++ b/TASVideos/Pages/Forum/Posts/New.cshtml
@@ -13,8 +13,8 @@
 	{
 		<fullrow class="pt-2">
 			<small>
-				<a asp-page="/Forum/Index">Forum</a> -> 
-				<a asp-page="/Forum/Subforum" asp-route-id="@post.ForumId">@post.ForumName</a> -> 
+				<a asp-page="/Forum/Index">Forum</a> →
+				<a asp-page="/Forum/Subforum" asp-route-id="@post.ForumId">@post.ForumName</a> →
 				<a asp-page="/Forum/Topics" asp-route-id="@post.TopicId">@post.TopicTitle</a>
 			</small>
 		</fullrow>

--- a/TASVideos/Pages/Forum/Posts/User.cshtml
+++ b/TASVideos/Pages/Forum/Posts/User.cshtml
@@ -25,7 +25,7 @@
 					</small>
 					<small class="pull-end">
 						<a asp-page="/Forum/Subforum/Index" asp-route-id="@post.ForumId">@Html.Raw(post.ForumName)</a>
-						 -> 
+						→
 						<a asp-page="/Forum/Topics/Index" asp-route-id="@post.TopicId">@post.TopicTitle</a>
 					</small>
 				</div>

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -24,7 +24,6 @@
 <div class="table-container">
 	<table class="table table-striped table-bordered">
 		<tr>
-			<th></th>
 			<th>Topics</th>
 			<th>Replies</th>
 			<th>Author</th>
@@ -34,13 +33,9 @@
 		{
 			<tr>
 				<td>
-					<span condition="@(topic.Type == ForumTopicType.Sticky)" class="fa fa-sticky-note"></span>
-					<span condition="@(topic.Type == ForumTopicType.Announcement)" class="fa fa-bullhorn"></span>
-				</td>
-				<td>
-					<a asp-page="/Forum/Topics/Index" asp-route-id="@topic.Id">
-						@Html.Raw(topic.Type.ToTitleHtml(topic.Title))
-					</a>
+					<span condition="@(topic.Type == ForumTopicType.Announcement)" class="fw-bold"><i class="fa fa-bullhorn"></i> Announcement: </span>
+					<span condition="@(topic.Type == ForumTopicType.Sticky)" class="fw-bold"><i class="fa fa-sticky-note"></i> Sticky: </span>
+					<a asp-page="/Forum/Topics/Index" asp-route-id="@topic.Id">@topic.Title</a>
 				</td>
 				<td>@Math.Max(0, topic.PostCount - 1)</td> @*Imported Submission Topics will have no replies and no original post*@
 				<td> <profile-link username="@topic.CreateUserName"></profile-link></td>

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml
@@ -2,14 +2,19 @@
 @using TASVideos.Data.Entity.Forum
 @model IndexModel
 @{
-	ViewData["Title"] = $"TASVideos Forum {Model.Forum.Name}";
+	ViewData["Title"] = $"{Model.Forum.Name} - Subforum";
+}
+@section PageTitle {
+	<div class="container mb-2">
+		<h1>@(Model.Forum.Name)</h1>
+	</div>
 }
 
 <partial Name="_ForumHeader" />
 <a permission="EditForums" asp-page="Edit" asp-route-id="@Model.Forum.Id" class="float-end btn btn-primary btn-sm border border-warning"><i class="fa fa-pencil"></i> Edit</a>
 <a permission="CreateForumTopics" asp-page="/Forum/Topics/Create" asp-route-forumId="@Model.Forum.Id" class="me-2 float-end btn btn-primary btn-sm"><span class="fa fa-plus"></span> New Topic</a>
 <h4>
-	<a asp-page="/Forum/Index">Forum</a> -> @Model.Forum.Name
+	<a asp-page="/Forum/Index">Forum</a> → @Model.Forum.Name
 </h4>
 <div>
 	<small>@Html.Raw(Model.Forum.Description)</small>
@@ -39,14 +44,14 @@
 				</td>
 				<td>@Math.Max(0, topic.PostCount - 1)</td> @*Imported Submission Topics will have no replies and no original post*@
 				<td> <profile-link username="@topic.CreateUserName"></profile-link></td>
-                <td>
-                    @if (topic.LastPost != null)
-                    {
-                        <timezone-convert asp-for="@topic.LastPostDateTime" /> <br />
+				<td>
+					@if (topic.LastPost != null)
+					{
+						<timezone-convert asp-for="@topic.LastPostDateTime" /> <br />
 						<profile-link username="@topic.LastPostUserName"></profile-link>
-                        <a class="fa fa-arrow-circle-right" href="/Forum/p/@topic.LastPostId#@topic.LastPostId"/>
-                    }
-                    </td>
+						<a class="fa fa-arrow-circle-right" href="/Forum/p/@topic.LastPostId#@topic.LastPostId" />
+					}
+				</td>
 			</tr>
 		}
 	</table>

--- a/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
+++ b/TASVideos/Pages/Forum/Subforum/Index.cshtml.cs
@@ -64,8 +64,8 @@ namespace TASVideos.Pages.Forum.Subforum
 					PostCount = ft.ForumPosts.Count,
 					LastPost = ft.ForumPosts.OrderByDescending(fp => fp.CreateTimestamp).First()
 				})
-				.OrderByDescending(ft => ft.Type == ForumTopicType.Sticky)
-				.ThenByDescending(ft => ft.Type == ForumTopicType.Announcement)
+				.OrderByDescending(ft => ft.Type == ForumTopicType.Announcement)
+				.ThenByDescending(ft => ft.Type == ForumTopicType.Sticky)
 				.ThenByDescending(ft => ft.LastPost)
 				.Skip(rowsToSkip)
 				.Take(Search.PageSize ?? ForumConstants.TopicsPerForum)

--- a/TASVideos/Pages/Forum/Topics/Index.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Index.cshtml
@@ -2,12 +2,18 @@
 @using TASVideos.Data.Helpers
 @model IndexModel
 @{
-	ViewData["Title"] = $"TASVideos Forum {Model.Topic.Title}";
+	ViewData["Title"] = $"{Model.Topic.Title} - Topic {Model.Topic.Id}";
+}
+@section PageTitle {
+	<div class="container mb-2">
+		<h1 class="fs-4">@(Model.Topic.Title)</h1>
+		<h6 condition="@Model.Topic.IsLocked" class="alert alert-danger py-2 m-0"><i class="fa fa-lock"></i> Locked</h6>
+	</div>
 }
 <partial Name="_ForumHeader" />
 <fullrow>
-	<partial name="_TopicActionBar" model="Model.Topic" />
 	<partial name="_TopicCrumbs" model="Model.Topic" />
+	<partial name="_TopicActionBar" model="Model.Topic" />
 	<a condition="ViewData.UserHas(PermissionTo.PostInLockedTopics)
 		|| (!Model.Topic.IsLocked && ViewData.UserHas(PermissionTo.CreateForumPosts))"
 	   asp-page="/Forum/Posts/Create"

--- a/TASVideos/Pages/Forum/Topics/Merge.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Merge.cshtml
@@ -6,7 +6,7 @@
 <partial Name="_ForumHeader" />
 <h4>
 	Merging Topic:
-	<a asp-page="/Forum/SubForum/Index" asp-route-id="@Model.Topic.ForumId">@Model.Topic.ForumName</a> ->
+	<a asp-page="/Forum/SubForum/Index" asp-route-id="@Model.Topic.ForumId">@Model.Topic.ForumName</a> →
 	<a asp-page="/Forum/Topics/Index" asp-route-id="@Model.Id">@Model.Topic.Title</a>
 </h4>
 <hr />

--- a/TASVideos/Pages/Forum/Topics/Move.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Move.cshtml
@@ -5,8 +5,8 @@
 }
 <partial Name="_ForumHeader" />
 <h4>
-	Moving Topic: 
-	<a asp-page="/Forum/SubForum/Index" asp-route-id="@Model.Topic.ForumId">@Model.Topic.ForumName</a> -> 
+	Moving Topic:
+	<a asp-page="/Forum/SubForum/Index" asp-route-id="@Model.Topic.ForumId">@Model.Topic.ForumName</a> →
 	<a asp-page="Topic" asp-route-id="@Model.Id">@Model.Topic.TopicTitle</a>
 </h4>
 <hr />

--- a/TASVideos/Pages/Forum/Topics/Split.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Split.cshtml
@@ -5,8 +5,8 @@
 }
 <partial Name="_ForumHeader" />
 <h4>
-	Splitting Topic: 
-	<a asp-page="/Forum/SubForum/Index" asp-route-id="@Model.Topic.ForumId">@Model.Topic.ForumName</a> -> 
+	Splitting Topic:
+	<a asp-page="/Forum/SubForum/Index" asp-route-id="@Model.Topic.ForumId">@Model.Topic.ForumName</a> →
 	<a asp-page="/Forum/Topics/Index" asp-route-id="@Model.Id">@Model.Topic.Title</a>
 </h4>
 <hr />

--- a/TASVideos/Pages/Forum/Topics/_TopicCrumbs.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicCrumbs.cshtml
@@ -1,9 +1,7 @@
 ﻿@model IForumTopicBreadCrumb
 
-<small class="@(Model.IsLocked ? "alert alert-danger" : "") pt-1 pb-2">
+<h4 class="pt-1 pb-2">
 	<a asp-page="/Forum/Index">Forum</a>
-	->
+	→
 	<a asp-page="/Forum/Subforum/Index" asp-route-id="@Model.ForumId">@Model.ForumName</a>
-	-> @Html.Raw(Model.Type.ToTitleHtml(Model.Title))
-	<span condition="Model.IsLocked"> (Locked)</span>
-</small>
+</h4>

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -109,7 +109,7 @@
 				<div class="mb-auto">
 					<forum-markup markup=@Model.Text enable-html=@Model.EnableHtml enable-bb-code=@Model.EnableBbCode></forum-markup>
 				</div>
-				<div condition="!string.IsNullOrWhiteSpace(Model.Signature)" class="forum-signature mt-2">
+				<div condition="!string.IsNullOrWhiteSpace(Model.Signature)" class="forum-signature mt-2 d-none d-md-block">
 					<small>
 						<forum-markup markup=@Model.Signature enable-html=false enable-bb-code=true></forum-markup>
 					</small>

--- a/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
+++ b/TASVideos/Pages/Forum/Topics/_TopicPost.cshtml
@@ -24,7 +24,7 @@
 					<a condition="User.IsLoggedIn()"
 					   asp-page="/Messages/Create"
 					   asp-route-defaultToUser="@Model.PosterName"
-					   class="btn btn-secondary btn-sm">
+					   class="btn btn-secondary btn-sm d-none d-md-inline-block">
 						<i class="fa fa-envelope"></i> PM
 					</a>
 					<a asp-page="/Forum/Posts/Create"

--- a/TASVideos/Pages/Games/PublicationHistory.cshtml
+++ b/TASVideos/Pages/Games/PublicationHistory.cshtml
@@ -6,7 +6,9 @@
 	ViewData["HighlightClass"] = "font-weight-bold font-italic border border-info p-1";
 }
 @section PageTitle {
-	<h1>@ViewData["Title"]</h1>
+	<div class="container mb-2">
+		<h1>@ViewData["Title"]</h1>
+	</div>
 }
 
 <h4><a asp-page="Index" asp-route-id="@Model.Id">@Model.Game.DisplayName</a></h4>

--- a/TASVideos/Pages/Publications/Edit.cshtml
+++ b/TASVideos/Pages/Publications/Edit.cshtml
@@ -11,7 +11,9 @@
 	}
 }
 @section PageTitle {
-	<h1>@Model.Publication.Title</h1>
+	<div class="container mb-2">
+		<h1>@Model.Publication.Title</h1>
+	</div>
 }
 
 <fullrow class="mt-2">

--- a/TASVideos/Pages/Publications/View.cshtml
+++ b/TASVideos/Pages/Publications/View.cshtml
@@ -1,7 +1,7 @@
 ﻿@page "{id}"
 @model ViewModel
 @{
-	ViewData["Title"] = $"Movie #{Model.Id}";
+	ViewData["Title"] = $"{Model.Publication.Title} - Movie #{Model.Id}";
 }
 @section PageTitle { }
 

--- a/TASVideos/Pages/Ratings/Index.cshtml
+++ b/TASVideos/Pages/Ratings/Index.cshtml
@@ -4,7 +4,9 @@
 	ViewData["Title"] = $"Ratings for #{Model.Publication.PublicationTitle}";
 }
 @section PageTitle {
-	<h1>Rating Details for @Model.Publication.PublicationTitle</h1>
+	<div class="container mb-2">
+		<h1>Rating Details for @Model.Publication.PublicationTitle</h1>
+	</div>
 }
 
 @if (Model.Publication.Ratings.Any())

--- a/TASVideos/Pages/Shared/Components/DisplayMiniMovie/Default.cshtml
+++ b/TASVideos/Pages/Shared/Components/DisplayMiniMovie/Default.cshtml
@@ -3,16 +3,16 @@
 <div condition="Model != null">
 	<div class="card minimovie">
 		<div class="card-header bg-cardprimary">
-			<h5><span class="float-end badge bg-info text-dark m-1">Featured</span></h5>
-            <h4><pub-link id="Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></pub-link></h4>
+			<h5><span class="float-end badge bg-info text-dark">Featured</span></h5>
+			<h4><pub-link id="Model.Id" class="text-decoration-none"><span class="text-dark">@Model.Title</span></pub-link></h4>
 		</div>
 		<div class="card-body bg-cardsecondary">
 			<pub-link id="Model.Id">
-                <div class="float-start pe-3 pb-1" style="max-width: 80%">
-                    <img class="w-100 pixelart-image pb-1" src="~/media/@Model.Screenshot.Path" alt="@Model.Screenshot.Description" />
-                    <br />
+				<div class="float-start pe-3 pb-1" style="max-width: 80%">
+					<img class="w-100 pixelart-image pb-1" src="~/media/@Model.Screenshot.Path" alt="@Model.Screenshot.Description" />
+					<br />
 					<a href="@Model.OnlineWatchingUrl" class="btn btn-primary" target="_blank"><i class="fa fa-external-link"></i> Watch</a>
-                </div>
+				</div>
 			</pub-link>
 			@await Component.RenderWiki(LinkConstants.PublicationWikiPage + Model.Id)
 		</div>

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -94,8 +94,8 @@
 	}
 	else
 	{
-		<div class="container">
-			<h1 class="mb-2 container">@title</h1>
+		<div class="container mb-2">
+			<h1>@title</h1>
 		</div>
 	}
 

--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -40,7 +40,7 @@
 }
 
 @section PageTitle {
-	<div class="container">
+	<div class="container mb-2">
 		<h1>@($"Submission {Model.Submission.Title}")</h1>
 	</div>
 }

--- a/TASVideos/Pages/Submissions/View.cshtml
+++ b/TASVideos/Pages/Submissions/View.cshtml
@@ -2,7 +2,7 @@
 @using TASVideos.Pages.Submissions.Models
 @model ViewModel
 @{
-	ViewData["Title"] = $"Submission #{Model.Id}";
+	ViewData["Title"] = $"{Model.Submission.Title} - Submission #{Model.Id}";
 	bool hasEncode = !string.IsNullOrWhiteSpace(Model.Submission.EncodeEmbedLink);
 	bool canEdit = ViewData.UserHas(PermissionTo.EditSubmissions)
 		|| (Model.CanEdit && ViewData.UserHas(PermissionTo.SubmitMovies));

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -282,3 +282,9 @@ article.wiki, .postbody {
 .fa {
 	transform: translate(0);
 }
+
+.card-header {
+	h1, h2, h3, h4, h5, h6 {
+		margin-bottom: 0;
+	}
+}


### PR DESCRIPTION
- Normalize document titles to
Content title - Location - TASVideos
- Center headers inside card-headers by removing margin (how bootstrap intended)
- Change -> to →
(is non-ascii a problem? a bootstrap arrow icons would work, but make copying bad)
- Hide signatures in mobile view
- Fix maximum width h1 titles by putting them into a container (how the default layout does it)
- Swaps order of Announcement and Sticky topics to fit with old site

Fixes one problem mentioned in #342.