### PR TITLE
Wiki Text Renderer System with Frames module implemented

### DIFF
--- a/TASVideos.WikiEngine/NodeImplementations.cs
+++ b/TASVideos.WikiEngine/NodeImplementations.cs
@@ -436,7 +436,8 @@ namespace TASVideos.WikiEngine.AST
 			}
 			else if (WikiModules.IsModule(Name))
 			{
-				// TODO: Modules in text.  We do need this
+				// It's the caller's responsibility to provide a view component runner that will create text output.
+				await ctx.Helper.RunViewComponentAsync(writer, Name, Parameters);
 			}
 			else
 			{

--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using TASVideos.Data.Entity;
 using TASVideos.Models;
 using TASVideos.MovieParsers;
 using TASVideos.Pages;
+using TASVideos.ViewComponents;
 
 namespace TASVideos.Extensions
 {
@@ -119,6 +120,10 @@ namespace TASVideos.Extensions
 
 			services.AddHttpContext();
 			services.AddMvc(options => options.ValueProviderFactories.AddDelimitedValueProviderFactory('|'));
+
+			// TODO: make extension method
+			services.AddScoped<Frames>();
+
 			return services;
 		}
 

--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ using TASVideos.Data.Entity;
 using TASVideos.Models;
 using TASVideos.MovieParsers;
 using TASVideos.Pages;
-using TASVideos.ViewComponents;
+using TASVideos.Services;
 
 namespace TASVideos.Extensions
 {
@@ -121,8 +121,15 @@ namespace TASVideos.Extensions
 			services.AddHttpContext();
 			services.AddMvc(options => options.ValueProviderFactories.AddDelimitedValueProviderFactory('|'));
 
-			// TODO: make extension method
-			services.AddScoped<Frames>();
+			return services;
+		}
+
+		public static IServiceCollection AddTextModules(this IServiceCollection services)
+		{
+			foreach (var component in WikiToTextRenderer.TextComponents.Values)
+			{
+				services.AddScoped(component);
+			}
 
 			return services;
 		}

--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -126,7 +126,7 @@ namespace TASVideos.Extensions
 
 		public static IServiceCollection AddTextModules(this IServiceCollection services)
 		{
-			foreach (var component in WikiToTextRenderer.TextComponents.Values)
+			foreach (var component in ModuleParamHelpers.TextComponents.Values)
 			{
 				services.AddScoped(component);
 			}

--- a/TASVideos/Pages/Shared/_PreviewWindow.cshtml
+++ b/TASVideos/Pages/Shared/_PreviewWindow.cshtml
@@ -1,4 +1,4 @@
-﻿@model (string, string)
+﻿@model (string ElementId, string PreviewPath)
 
 <div id="preview-container" class="d-none">
 	<hr />
@@ -13,7 +13,7 @@
 <script>
 	(function () {
 		document.getElementById('preview-button').onclick = function () {
-			var markup = document.getElementById('@Model.Item1').value;
+			var markup = document.getElementById('@Model.ElementId').value;
 			document.getElementById('preview-container').classList.remove('d-none');
 			var xmlhttp = new XMLHttpRequest();
 			xmlhttp.onreadystatechange = function() {
@@ -27,7 +27,7 @@
 				}
 			};
 
-			xmlhttp.open("POST", "@Model.Item2");
+			xmlhttp.open("POST", "@Model.PreviewPath");
 			xmlhttp.send(markup);
 		}
 	})();

--- a/TASVideos/Pages/Wiki/Preview.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Preview.cshtml.cs
@@ -29,7 +29,6 @@ namespace TASVideos.Pages.Wiki
 		public async Task<IActionResult> OnPost()
 		{
 			Markup = await new StreamReader(Request.Body, Encoding.UTF8).ReadToEndAsync();
-
 			if (Id.HasValue)
 			{
 				PageData = await _pages.Revision(Id.Value);

--- a/TASVideos/Pages/Wiki/Preview.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Preview.cshtml.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TASVideos.Core.Services;
+using TASVideos.Core.Services.Youtube;
 using TASVideos.Data.Entity;
 
 namespace TASVideos.Pages.Wiki
@@ -13,10 +14,12 @@ namespace TASVideos.Pages.Wiki
 	public class PreviewModel : BasePageModel
 	{
 		private readonly IWikiPages _pages;
+		private readonly IWikiToTextRenderer _renderer;
 
-		public PreviewModel(IWikiPages pages)
+		public PreviewModel(IWikiPages pages, IWikiToTextRenderer renderer)
 		{
 			_pages = pages;
+			_renderer = renderer;
 		}
 
 		public string Markup { get; set; } = "";
@@ -29,12 +32,16 @@ namespace TASVideos.Pages.Wiki
 		public async Task<IActionResult> OnPost()
 		{
 			Markup = await new StreamReader(Request.Body, Encoding.UTF8).ReadToEndAsync();
-			if (Id.HasValue)
-			{
-				PageData = await _pages.Revision(Id.Value);
-			}
 
-			return Page();
+			var str = await _renderer.RenderWikiForYoutube(new WikiPage { Markup = Markup });
+			return new ContentResult { Content = str };
+
+			////if (Id.HasValue)
+			////{
+			////	PageData = await _pages.Revision(Id.Value);
+			////}
+
+			////return Page();
 		}
 	}
 }

--- a/TASVideos/Pages/Wiki/Preview.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Preview.cshtml.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TASVideos.Core.Services;
-using TASVideos.Core.Services.Youtube;
 using TASVideos.Data.Entity;
 
 namespace TASVideos.Pages.Wiki
@@ -14,12 +13,10 @@ namespace TASVideos.Pages.Wiki
 	public class PreviewModel : BasePageModel
 	{
 		private readonly IWikiPages _pages;
-		private readonly IWikiToTextRenderer _renderer;
 
-		public PreviewModel(IWikiPages pages, IWikiToTextRenderer renderer)
+		public PreviewModel(IWikiPages pages)
 		{
 			_pages = pages;
-			_renderer = renderer;
 		}
 
 		public string Markup { get; set; } = "";
@@ -33,15 +30,12 @@ namespace TASVideos.Pages.Wiki
 		{
 			Markup = await new StreamReader(Request.Body, Encoding.UTF8).ReadToEndAsync();
 
-			var str = await _renderer.RenderWikiForYoutube(new WikiPage { Markup = Markup });
-			return new ContentResult { Content = str };
+			if (Id.HasValue)
+			{
+				PageData = await _pages.Revision(Id.Value);
+			}
 
-			////if (Id.HasValue)
-			////{
-			////	PageData = await _pages.Revision(Id.Value);
-			////}
-
-			////return Page();
+			return Page();
 		}
 	}
 }

--- a/TASVideos/Services/IModuleParameterTypeAdapter.cs
+++ b/TASVideos/Services/IModuleParameterTypeAdapter.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using Namotion.Reflection;
-using TASVideos.Data.Entity;
-using TASVideos.TagHelpers;
-using TASVideos.ViewComponents;
-
-namespace TASVideos.Services
+﻿namespace TASVideos.Services
 {
 	public interface IModuleParameterTypeAdapter
 	{
@@ -21,89 +11,6 @@ namespace TASVideos.Services
 		object? IModuleParameterTypeAdapter.Convert(string? input)
 		{
 			return (object?)Convert(input);
-		}
-	}
-
-	public static class ModuleParamHelpers
-	{
-		public static readonly Dictionary<Type, IModuleParameterTypeAdapter> ParamTypeAdapters = typeof(WikiMarkup)
-			.Assembly
-			.GetTypes()
-			.Where(t => t.BaseType != null
-				&& t.BaseType.IsGenericType
-				&& t.BaseType.GetGenericTypeDefinition() == typeof(ModuleParameterTypeAdapter<>))
-			.ToDictionary(
-				t => t.BaseType!.GetGenericArguments()[0],
-				t => (IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
-
-		public static readonly IDictionary<string, Type> ViewComponents = Assembly
-			.GetAssembly(typeof(WikiModuleAttribute))
-			!.GetTypes()
-			.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
-			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
-
-		// TODO: reuse code above
-		public static readonly IDictionary<string, Type> TextComponents = Assembly
-			.GetAssembly(typeof(WikiModuleAttribute))
-			!.GetTypes()
-			.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
-			.Where(t => t.GetCustomAttribute(typeof(TextModuleAttribute)) != null)
-			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
-
-		public static IDictionary<string, object?> GetParameterData(
-			TextWriter w,
-			string name,
-			MethodInfo invokeMethod,
-			WikiPage pageData,
-			IReadOnlyDictionary<string, string> pp)
-		{
-			var paramObject = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-			{
-				{ "pageData", pageData }
-			};
-
-			var paramCandidates = invokeMethod
-				.GetParameters()
-				.Where(p => !paramObject.ContainsKey(p.Name!)); // filter out any already supplied parameters
-
-			foreach (var paramCandidate in paramCandidates)
-			{
-				var paramType = paramCandidate.ParameterType;
-				var adapterKeyType = paramType;
-				var doNullableWrap = paramType.IsValueType
-					&& (!paramType.IsGenericType || paramType.GetGenericTypeDefinition() != typeof(Nullable<>));
-
-				if (doNullableWrap)
-				{
-					adapterKeyType = typeof(Nullable<>).MakeGenericType(adapterKeyType);
-				}
-
-				if (!ParamTypeAdapters.TryGetValue(adapterKeyType, out var adapter))
-				{
-					// These should all exist at compile time.
-					throw new InvalidOperationException($"Unknown ViewComponent Argument Type: {adapterKeyType}");
-				}
-
-				pp.TryGetValue(paramCandidate.Name!, out var ppValue);
-				var result = adapter.Convert(ppValue);
-
-				if (result == null)
-				{
-					// Conversion failed.  See if the parameter type is a failable type.
-					var needsNonNull = paramType.IsValueType && doNullableWrap
-						|| !paramType.IsValueType && paramType.ToContextualType().Nullability == Nullability.NotNullable;
-					if (needsNonNull)
-					{
-						// TODO: Better styling, or something
-						w.Write($"MODULE ERROR for `{name}`: Missing parameter value for {paramCandidate.Name}");
-						return new Dictionary<string, object?>();
-					}
-				}
-
-				paramObject[paramCandidate.Name!] = result;
-			}
-
-			return paramObject;
 		}
 	}
 }

--- a/TASVideos/Services/IModuleParameterTypeAdapter.cs
+++ b/TASVideos/Services/IModuleParameterTypeAdapter.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using Namotion.Reflection;
+using TASVideos.Data.Entity;
 using TASVideos.TagHelpers;
 using TASVideos.ViewComponents;
 
@@ -47,6 +50,60 @@ namespace TASVideos.Services
 			.Where(t => t.GetCustomAttribute(typeof(TextModuleAttribute)) != null)
 			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
 
+		public static IDictionary<string, object?> GetParameterData(
+			TextWriter w,
+			string name,
+			MethodInfo invokeMethod,
+			WikiPage pageData,
+			IReadOnlyDictionary<string, string> pp)
+		{
+			var paramObject = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+			{
+				{ "pageData", pageData }
+			};
 
+			var paramCandidates = invokeMethod
+				.GetParameters()
+				.Where(p => !paramObject.ContainsKey(p.Name!)); // filter out any already supplied parameters
+
+			foreach (var paramCandidate in paramCandidates)
+			{
+				var paramType = paramCandidate.ParameterType;
+				var adapterKeyType = paramType;
+				var doNullableWrap = paramType.IsValueType
+					&& (!paramType.IsGenericType || paramType.GetGenericTypeDefinition() != typeof(Nullable<>));
+
+				if (doNullableWrap)
+				{
+					adapterKeyType = typeof(Nullable<>).MakeGenericType(adapterKeyType);
+				}
+
+				if (!ParamTypeAdapters.TryGetValue(adapterKeyType, out var adapter))
+				{
+					// These should all exist at compile time.
+					throw new InvalidOperationException($"Unknown ViewComponent Argument Type: {adapterKeyType}");
+				}
+
+				pp.TryGetValue(paramCandidate.Name!, out var ppValue);
+				var result = adapter.Convert(ppValue);
+
+				if (result == null)
+				{
+					// Conversion failed.  See if the parameter type is a failable type.
+					var needsNonNull = paramType.IsValueType && doNullableWrap
+						|| !paramType.IsValueType && paramType.ToContextualType().Nullability == Nullability.NotNullable;
+					if (needsNonNull)
+					{
+						// TODO: Better styling, or something
+						w.Write($"MODULE ERROR for `{name}`: Missing parameter value for {paramCandidate.Name}");
+						return new Dictionary<string, object?>();
+					}
+				}
+
+				paramObject[paramCandidate.Name!] = result;
+			}
+
+			return paramObject;
+		}
 	}
 }

--- a/TASVideos/Services/IModuleParameterTypeAdapter.cs
+++ b/TASVideos/Services/IModuleParameterTypeAdapter.cs
@@ -1,4 +1,11 @@
-﻿namespace TASVideos.Services
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TASVideos.TagHelpers;
+using TASVideos.ViewComponents;
+
+namespace TASVideos.Services
 {
 	public interface IModuleParameterTypeAdapter
 	{
@@ -12,5 +19,34 @@
 		{
 			return (object?)Convert(input);
 		}
+	}
+
+	public static class ModuleParamHelpers
+	{
+		public static readonly Dictionary<Type, IModuleParameterTypeAdapter> ParamTypeAdapters = typeof(WikiMarkup)
+			.Assembly
+			.GetTypes()
+			.Where(t => t.BaseType != null
+				&& t.BaseType.IsGenericType
+				&& t.BaseType.GetGenericTypeDefinition() == typeof(ModuleParameterTypeAdapter<>))
+			.ToDictionary(
+				t => t.BaseType!.GetGenericArguments()[0],
+				t => (IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
+
+		public static readonly IDictionary<string, Type> ViewComponents = Assembly
+			.GetAssembly(typeof(WikiModuleAttribute))
+			!.GetTypes()
+			.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
+			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
+
+		// TODO: reuse code above
+		public static readonly IDictionary<string, Type> TextComponents = Assembly
+			.GetAssembly(typeof(WikiModuleAttribute))
+			!.GetTypes()
+			.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
+			.Where(t => t.GetCustomAttribute(typeof(TextModuleAttribute)) != null)
+			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
+
+
 	}
 }

--- a/TASVideos/Services/IModuleParameterTypeAdapter.cs
+++ b/TASVideos/Services/IModuleParameterTypeAdapter.cs
@@ -1,0 +1,16 @@
+﻿namespace TASVideos.Services
+{
+	public interface IModuleParameterTypeAdapter
+	{
+		object? Convert(string? input);
+	}
+
+	public abstract class ModuleParameterTypeAdapter<T> : IModuleParameterTypeAdapter
+	{
+		public abstract T Convert(string? input);
+		object? IModuleParameterTypeAdapter.Convert(string? input)
+		{
+			return (object?)Convert(input);
+		}
+	}
+}

--- a/TASVideos/Services/ModuleParamHelpers.cs
+++ b/TASVideos/Services/ModuleParamHelpers.cs
@@ -81,6 +81,7 @@ namespace TASVideos.Services
 					if (needsNonNull)
 					{
 						// TODO: Better styling, or something
+						// TODO: do not pass in TextWriter and this isn't how it should report that failure. We should return some failure state to the caller which can then handle output
 						w.Write($"MODULE ERROR for `{name}`: Missing parameter value for {paramCandidate.Name}");
 						return new Dictionary<string, object?>();
 					}

--- a/TASVideos/Services/ModuleParamHelpers.cs
+++ b/TASVideos/Services/ModuleParamHelpers.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Namotion.Reflection;
+using TASVideos.Data.Entity;
+using TASVideos.TagHelpers;
+using TASVideos.ViewComponents;
+
+namespace TASVideos.Services
+{
+	public static class ModuleParamHelpers
+	{
+		public static readonly Dictionary<Type, IModuleParameterTypeAdapter> ParamTypeAdapters = typeof(WikiMarkup)
+			.Assembly
+			.GetTypes()
+			.Where(t => t.BaseType != null
+				&& t.BaseType.IsGenericType
+				&& t.BaseType.GetGenericTypeDefinition() == typeof(ModuleParameterTypeAdapter<>))
+			.ToDictionary(
+				t => t.BaseType!.GetGenericArguments()[0],
+				t => (IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
+
+		public static readonly IDictionary<string, Type> ViewComponents = Assembly
+			.GetAssembly(typeof(WikiModuleAttribute))
+			!.GetTypes()
+			.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
+			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
+
+		// TODO: reuse code above
+		public static readonly IDictionary<string, Type> TextComponents = Assembly
+			.GetAssembly(typeof(WikiModuleAttribute))
+			!.GetTypes()
+			.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
+			.Where(t => t.GetCustomAttribute(typeof(TextModuleAttribute)) != null)
+			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
+
+		public static IDictionary<string, object?> GetParameterData(
+			TextWriter w,
+			string name,
+			MethodInfo invokeMethod,
+			WikiPage pageData,
+			IReadOnlyDictionary<string, string> pp)
+		{
+			var paramObject = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+			{
+				{ "pageData", pageData }
+			};
+
+			var paramCandidates = invokeMethod
+				.GetParameters()
+				.Where(p => !paramObject.ContainsKey(p.Name!)); // filter out any already supplied parameters
+
+			foreach (var paramCandidate in paramCandidates)
+			{
+				var paramType = paramCandidate.ParameterType;
+				var adapterKeyType = paramType;
+				var doNullableWrap = paramType.IsValueType
+					&& (!paramType.IsGenericType || paramType.GetGenericTypeDefinition() != typeof(Nullable<>));
+
+				if (doNullableWrap)
+				{
+					adapterKeyType = typeof(Nullable<>).MakeGenericType(adapterKeyType);
+				}
+
+				if (!ParamTypeAdapters.TryGetValue(adapterKeyType, out var adapter))
+				{
+					// These should all exist at compile time.
+					throw new InvalidOperationException($"Unknown ViewComponent Argument Type: {adapterKeyType}");
+				}
+
+				pp.TryGetValue(paramCandidate.Name!, out var ppValue);
+				var result = adapter.Convert(ppValue);
+
+				if (result == null)
+				{
+					// Conversion failed.  See if the parameter type is a failable type.
+					var needsNonNull = paramType.IsValueType && doNullableWrap
+						|| !paramType.IsValueType && paramType.ToContextualType().Nullability == Nullability.NotNullable;
+					if (needsNonNull)
+					{
+						// TODO: Better styling, or something
+						w.Write($"MODULE ERROR for `{name}`: Missing parameter value for {paramCandidate.Name}");
+						return new Dictionary<string, object?>();
+					}
+				}
+
+				paramObject[paramCandidate.Name!] = result;
+			}
+
+			return paramObject;
+		}
+	}
+}

--- a/TASVideos/Services/WikiToTextRenderer.cs
+++ b/TASVideos/Services/WikiToTextRenderer.cs
@@ -1,10 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Namotion.Reflection;
 using TASVideos.Core.Services.Youtube;
 using TASVideos.Core.Settings;
 using TASVideos.Data.Entity;
+using TASVideos.TagHelpers;
+using TASVideos.ViewComponents;
 using TASVideos.WikiEngine;
 using TASVideos.WikiEngine.AST;
 
@@ -13,23 +20,51 @@ namespace TASVideos.Services
 	public class WikiToTextRenderer : IWikiToTextRenderer
 	{
 		private readonly AppSettings _settings;
+		private readonly IServiceProvider _serviceProvider;
 
-		public WikiToTextRenderer(AppSettings settings)
+		public WikiToTextRenderer(AppSettings settings, IServiceProvider serviceProvider)
 		{
 			_settings = settings;
+			_serviceProvider = serviceProvider;
 		}
 
 		public async Task<string> RenderWikiForYoutube(WikiPage page)
 		{
 			var sw = new StringWriter();
-			await Util.RenderTextAsync(page.Markup, sw, new WriterHelper(_settings.BaseUrl));
+			await Util.RenderTextAsync(page.Markup, sw, new WriterHelper(_settings.BaseUrl, _serviceProvider, page));
 			return sw.ToString();
 		}
 
 		private class WriterHelper : IWriterHelper
 		{
+			private static readonly IDictionary<string, Type> TextComponents = Assembly
+				.GetAssembly(typeof(WikiModuleAttribute))
+				!.GetTypes()
+				.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
+				.Where(t => t.GetCustomAttribute(typeof(TextModuleAttribute)) != null)
+				.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
+
+			private static readonly Dictionary<Type, WikiMarkup.IModuleParameterTypeAdapter> ParamTypeAdapters = typeof(WikiMarkup)
+				.Assembly
+				.GetTypes()
+				.Where(t => t.BaseType != null
+					&& t.BaseType.IsGenericType
+					&& t.BaseType.GetGenericTypeDefinition() == typeof(WikiMarkup.ModuleParameterTypeAdapter<>))
+				.ToDictionary(
+					t => t.BaseType!.GetGenericArguments()[0],
+					t => (WikiMarkup.IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
+
 			private readonly string _host;
-			public WriterHelper(string host) { _host = host; }
+			private readonly IServiceProvider _serviceProvider;
+			private readonly WikiPage _wikiPage;
+
+			public WriterHelper(string host, IServiceProvider serviceProvider, WikiPage wikiPage)
+			{
+				_host = host;
+				_serviceProvider = serviceProvider;
+				_wikiPage = wikiPage;
+			}
+
 			public bool CheckCondition(string condition)
 			{
 				bool result = false;
@@ -53,10 +88,76 @@ namespace TASVideos.Services
 				return result;
 			}
 
-			public Task RunViewComponentAsync(TextWriter w, string name, IReadOnlyDictionary<string, string> pp)
+			public async Task RunViewComponentAsync(TextWriter w, string name, IReadOnlyDictionary<string, string> pp)
 			{
-				// TODO: This needs to be handled in concert with Wiki changes
-				return Task.CompletedTask;
+				var componentExists = TextComponents.TryGetValue(name, out Type? textComponent);
+				if (!componentExists)
+				{
+					return;
+				}
+
+				// TODO: copy-pasta from WikiMarkupTagHelper
+				var paramObject = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+				{
+					{ "pageData", _wikiPage }
+};
+
+				var invokeMethod = textComponent!.GetMethod("RenderTextAsync");
+				//?? textComponent.GetMethod("RenderText"); // TODO
+
+				if (invokeMethod == null)
+				{
+					throw new InvalidOperationException($"Could not find an RenderText method on ViewComponent {textComponent}");
+				}
+
+				var paramCandidates = invokeMethod
+					.GetParameters()
+					.Where(p => !paramObject.ContainsKey(p.Name!)); // filter out any already supplied parameters
+
+				foreach (var paramCandidate in paramCandidates)
+				{
+					var paramType = paramCandidate.ParameterType;
+					var adapterKeyType = paramType;
+					var doNullableWrap = paramType.IsValueType
+						&& (!paramType.IsGenericType || paramType.GetGenericTypeDefinition() != typeof(Nullable<>));
+
+					if (doNullableWrap)
+					{
+						adapterKeyType = typeof(Nullable<>).MakeGenericType(adapterKeyType);
+					}
+
+					if (!ParamTypeAdapters.TryGetValue(adapterKeyType, out var adapter))
+					{
+						// These should all exist at compile time.
+						throw new InvalidOperationException($"Unknown ViewComponent Argument Type: {adapterKeyType}");
+					}
+
+					pp.TryGetValue(paramCandidate.Name!, out var ppvalue);
+					var result = adapter.Convert(ppvalue);
+
+					if (result == null)
+					{
+						// Conversion failed.  See if the parameter type is a failable type.
+						var needsNonNull = paramType.IsValueType && doNullableWrap
+							|| !paramType.IsValueType && paramType.ToContextualType().Nullability == Nullability.NotNullable;
+						if (needsNonNull)
+						{
+							// TODO: Better styling, or something
+							w.Write($"MODULE ERROR for `{name}`: Missing parameter value for {paramCandidate.Name}");
+							return;
+						}
+					}
+
+					paramObject[paramCandidate.Name!] = result;
+				}
+
+				var module = _serviceProvider.GetRequiredService(textComponent);
+				var x = paramObject.Values.ToArray();
+				var task = (Task)invokeMethod.Invoke(module, x)!;
+				await task;
+				var resultProperty = task.GetType().GetProperty("Result")!;
+				var str = resultProperty.GetValue(task);
+				w.Write(str);
 			}
 
 			public string AbsoluteUrl(string url)

--- a/TASVideos/Services/WikiToTextRenderer.cs
+++ b/TASVideos/Services/WikiToTextRenderer.cs
@@ -90,12 +90,10 @@ namespace TASVideos.Services
 					.GetParameterData(w, name, invokeMethod, _wikiPage, pp);
 
 				var module = _serviceProvider.GetRequiredService(textComponent);
-				var x = paramObject.Values.ToArray();
-				var task = (Task)invokeMethod.Invoke(module, x)!;
+				var task = (Task)invokeMethod.Invoke(module, paramObject.Values.ToArray())!;
 				await task;
 				var resultProperty = task.GetType().GetProperty("Result")!;
-				var str = resultProperty.GetValue(task);
-				w.Write(str);
+				w.Write(resultProperty.GetValue(task));
 			}
 
 			public string AbsoluteUrl(string url)

--- a/TASVideos/Services/WikiToTextRenderer.cs
+++ b/TASVideos/Services/WikiToTextRenderer.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Namotion.Reflection;
 using TASVideos.Core.Services.Youtube;
@@ -28,6 +27,13 @@ namespace TASVideos.Services
 			_serviceProvider = serviceProvider;
 		}
 
+		public static readonly IDictionary<string, Type> TextComponents = Assembly
+			.GetAssembly(typeof(WikiModuleAttribute))
+			!.GetTypes()
+			.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
+			.Where(t => t.GetCustomAttribute(typeof(TextModuleAttribute)) != null)
+			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
+
 		public async Task<string> RenderWikiForYoutube(WikiPage page)
 		{
 			var sw = new StringWriter();
@@ -37,13 +43,6 @@ namespace TASVideos.Services
 
 		private class WriterHelper : IWriterHelper
 		{
-			private static readonly IDictionary<string, Type> TextComponents = Assembly
-				.GetAssembly(typeof(WikiModuleAttribute))
-				!.GetTypes()
-				.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
-				.Where(t => t.GetCustomAttribute(typeof(TextModuleAttribute)) != null)
-				.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
-
 			private static readonly Dictionary<Type, WikiMarkup.IModuleParameterTypeAdapter> ParamTypeAdapters = typeof(WikiMarkup)
 				.Assembly
 				.GetTypes()

--- a/TASVideos/Services/WikiToTextRenderer.cs
+++ b/TASVideos/Services/WikiToTextRenderer.cs
@@ -43,15 +43,15 @@ namespace TASVideos.Services
 
 		private class WriterHelper : IWriterHelper
 		{
-			private static readonly Dictionary<Type, WikiMarkup.IModuleParameterTypeAdapter> ParamTypeAdapters = typeof(WikiMarkup)
+			private static readonly Dictionary<Type, IModuleParameterTypeAdapter> ParamTypeAdapters = typeof(WikiMarkup)
 				.Assembly
 				.GetTypes()
 				.Where(t => t.BaseType != null
 					&& t.BaseType.IsGenericType
-					&& t.BaseType.GetGenericTypeDefinition() == typeof(WikiMarkup.ModuleParameterTypeAdapter<>))
+					&& t.BaseType.GetGenericTypeDefinition() == typeof(ModuleParameterTypeAdapter<>))
 				.ToDictionary(
 					t => t.BaseType!.GetGenericArguments()[0],
-					t => (WikiMarkup.IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
+					t => (IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
 
 			private readonly string _host;
 			private readonly IServiceProvider _serviceProvider;

--- a/TASVideos/Services/WikiToTextRenderer.cs
+++ b/TASVideos/Services/WikiToTextRenderer.cs
@@ -75,7 +75,11 @@ namespace TASVideos.Services
 				}
 
 				var invokeMethod = textComponent!.GetMethod("RenderTextAsync");
-				//?? textComponent.GetMethod("RenderText"); // TODO
+
+				if (invokeMethod == null && textComponent.GetMethod("RenderText") != null)
+				{
+					throw new NotImplementedException("Sync method not supported yet");
+				}
 
 				if (invokeMethod == null)
 				{

--- a/TASVideos/Services/WikiToTextRenderer.cs
+++ b/TASVideos/Services/WikiToTextRenderer.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Namotion.Reflection;
 using TASVideos.Core.Services.Youtube;
 using TASVideos.Core.Settings;
 using TASVideos.Data.Entity;
@@ -83,51 +82,8 @@ namespace TASVideos.Services
 					throw new InvalidOperationException($"Could not find an RenderText method on ViewComponent {textComponent}");
 				}
 
-				var paramObject = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-				{
-					{ "pageData", _wikiPage }
-				};
-
-				var paramCandidates = invokeMethod
-					.GetParameters()
-					.Where(p => !paramObject.ContainsKey(p.Name!)); // filter out any already supplied parameters
-
-				foreach (var paramCandidate in paramCandidates)
-				{
-					var paramType = paramCandidate.ParameterType;
-					var adapterKeyType = paramType;
-					var doNullableWrap = paramType.IsValueType
-						&& (!paramType.IsGenericType || paramType.GetGenericTypeDefinition() != typeof(Nullable<>));
-
-					if (doNullableWrap)
-					{
-						adapterKeyType = typeof(Nullable<>).MakeGenericType(adapterKeyType);
-					}
-
-					if (!ModuleParamHelpers.ParamTypeAdapters.TryGetValue(adapterKeyType, out var adapter))
-					{
-						// These should all exist at compile time.
-						throw new InvalidOperationException($"Unknown ViewComponent Argument Type: {adapterKeyType}");
-					}
-
-					pp.TryGetValue(paramCandidate.Name!, out var ppvalue);
-					var result = adapter.Convert(ppvalue);
-
-					if (result == null)
-					{
-						// Conversion failed.  See if the parameter type is a failable type.
-						var needsNonNull = paramType.IsValueType && doNullableWrap
-							|| !paramType.IsValueType && paramType.ToContextualType().Nullability == Nullability.NotNullable;
-						if (needsNonNull)
-						{
-							// TODO: Better styling, or something
-							w.Write($"MODULE ERROR for `{name}`: Missing parameter value for {paramCandidate.Name}");
-							return;
-						}
-					}
-
-					paramObject[paramCandidate.Name!] = result;
-				}
+				var paramObject = ModuleParamHelpers
+					.GetParameterData(w, name, invokeMethod, _wikiPage, pp);
 
 				var module = _serviceProvider.GetRequiredService(textComponent);
 				var x = paramObject.Values.ToArray();

--- a/TASVideos/Startup.cs
+++ b/TASVideos/Startup.cs
@@ -35,7 +35,8 @@ namespace TASVideos
 				.AddCookieConfiguration(Environment)
 				.AddGzipCompression(Settings)
 				.AddAutoMapperWithProjections()
-				.AddSwagger(Settings);
+				.AddSwagger(Settings)
+				.AddTextModules();
 
 			// Internal Libraries
 			services

--- a/TASVideos/TagHelpers/WikiMarkupTagHelper.ParamConverters.cs
+++ b/TASVideos/TagHelpers/WikiMarkupTagHelper.ParamConverters.cs
@@ -12,18 +12,9 @@ namespace TASVideos.TagHelpers
 		/// </summary>
 		public static T ConvertParameter<T>(string? input)
 		{
-			return ((ModuleParameterTypeAdapter<T>)ParamTypeAdapters[typeof(T)]).Convert(input);
+			return ((ModuleParameterTypeAdapter<T>)ModuleParamHelpers
+				.ParamTypeAdapters[typeof(T)]).Convert(input);
 		}
-
-		private static readonly Dictionary<Type, IModuleParameterTypeAdapter> ParamTypeAdapters = typeof(WikiMarkup)
-			.Assembly
-			.GetTypes()
-			.Where(t => t.BaseType != null
-				&& t.BaseType.IsGenericType
-				&& t.BaseType.GetGenericTypeDefinition() == typeof(ModuleParameterTypeAdapter<>))
-			.ToDictionary(
-				t => t.BaseType!.GetGenericArguments()[0],
-				t => (IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
 
 		private class StringConverter : ModuleParameterTypeAdapter<string?>
 		{

--- a/TASVideos/TagHelpers/WikiMarkupTagHelper.ParamConverters.cs
+++ b/TASVideos/TagHelpers/WikiMarkupTagHelper.ParamConverters.cs
@@ -24,12 +24,12 @@ namespace TASVideos.TagHelpers
 				t => t.BaseType!.GetGenericArguments()[0],
 				t => (IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
 
-		private interface IModuleParameterTypeAdapter
+		public interface IModuleParameterTypeAdapter
 		{
 			object? Convert(string? input);
 		}
 
-		private abstract class ModuleParameterTypeAdapter<T> : IModuleParameterTypeAdapter
+		public abstract class ModuleParameterTypeAdapter<T> : IModuleParameterTypeAdapter
 		{
 			public abstract T Convert(string? input);
 			object? IModuleParameterTypeAdapter.Convert(string? input)

--- a/TASVideos/TagHelpers/WikiMarkupTagHelper.ParamConverters.cs
+++ b/TASVideos/TagHelpers/WikiMarkupTagHelper.ParamConverters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using TASVideos.Services;
 
 namespace TASVideos.TagHelpers
 {
@@ -23,20 +24,6 @@ namespace TASVideos.TagHelpers
 			.ToDictionary(
 				t => t.BaseType!.GetGenericArguments()[0],
 				t => (IModuleParameterTypeAdapter)Activator.CreateInstance(t)!);
-
-		public interface IModuleParameterTypeAdapter
-		{
-			object? Convert(string? input);
-		}
-
-		public abstract class ModuleParameterTypeAdapter<T> : IModuleParameterTypeAdapter
-		{
-			public abstract T Convert(string? input);
-			object? IModuleParameterTypeAdapter.Convert(string? input)
-			{
-				return (object?)Convert(input);
-			}
-		}
 
 		private class StringConverter : ModuleParameterTypeAdapter<string?>
 		{

--- a/TASVideos/TagHelpers/WikiMarkupTagHelper.cs
+++ b/TASVideos/TagHelpers/WikiMarkupTagHelper.cs
@@ -2,12 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Text.Encodings.Web;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -15,7 +11,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 using Namotion.Reflection;
 using TASVideos.Data.Entity;
 using TASVideos.Extensions;
-using TASVideos.ViewComponents;
+using TASVideos.Services;
 using TASVideos.WikiEngine;
 using TASVideos.WikiEngine.AST;
 
@@ -50,24 +46,13 @@ namespace TASVideos.TagHelpers
 			return HtmlExtensions.WikiCondition(ViewContext, condition);
 		}
 
-		private static readonly IDictionary<string, Type> ViewComponents = Assembly
-			.GetAssembly(typeof(WikiModuleAttribute))
-			!.GetTypes()
-			.Where(t => t.GetCustomAttribute(typeof(WikiModuleAttribute)) != null)
-			.ToDictionary(tkey => ((WikiModuleAttribute)tkey.GetCustomAttribute(typeof(WikiModuleAttribute))!).Name, tvalue => tvalue, StringComparer.InvariantCultureIgnoreCase);
-
 		async Task IWriterHelper.RunViewComponentAsync(TextWriter w, string name, IReadOnlyDictionary<string, string> pp)
 		{
-			var componentExists = ViewComponents.TryGetValue(name, out Type? viewComponent);
+			var componentExists = ModuleParamHelpers.ViewComponents.TryGetValue(name, out Type? viewComponent);
 			if (!componentExists)
 			{
 				throw new InvalidOperationException($"Unknown ViewComponent: {name}");
 			}
-
-			var paramObject = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-			{
-				{ "pageData", PageData }
-			};
 
 			var invokeMethod = viewComponent!.GetMethod("InvokeAsync")
 				?? viewComponent.GetMethod("Invoke");
@@ -76,6 +61,11 @@ namespace TASVideos.TagHelpers
 			{
 				throw new InvalidOperationException($"Could not find an Invoke method on ViewComponent {viewComponent}");
 			}
+
+			var paramObject = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+			{
+				{ "pageData", PageData }
+			};
 
 			var paramCandidates = invokeMethod
 				.GetParameters()
@@ -93,7 +83,7 @@ namespace TASVideos.TagHelpers
 					adapterKeyType = typeof(Nullable<>).MakeGenericType(adapterKeyType);
 				}
 
-				if (!ParamTypeAdapters.TryGetValue(adapterKeyType, out var adapter))
+				if (!ModuleParamHelpers.ParamTypeAdapters.TryGetValue(adapterKeyType, out var adapter))
 				{
 					// These should all exist at compile time.
 					throw new InvalidOperationException($"Unknown ViewComponent Argument Type: {adapterKeyType}");

--- a/TASVideos/ViewComponents/Frames.cs
+++ b/TASVideos/ViewComponents/Frames.cs
@@ -11,6 +11,7 @@ using TASVideos.WikiEngine;
 namespace TASVideos.ViewComponents
 {
 	[WikiModule(WikiModules.Frames)]
+	[TextModule]
 	public class Frames : ViewComponent
 	{
 		private const string CacheKey = "FramesModule";
@@ -21,6 +22,17 @@ namespace TASVideos.ViewComponents
 		{
 			_db = db;
 			_cache = cache;
+		}
+
+		public async Task<string> RenderTextAsync(WikiPage pageData, double? fps, int amount)
+		{
+			var model = new FramesModel
+			{
+				Amount = amount,
+				Fps = fps ?? await GuessFps(pageData.PageName)
+			};
+
+			return model.TimeSpan.ToCondensedString();
 		}
 
 		public async Task<IViewComponentResult> InvokeAsync(WikiPage pageData, double? fps, int amount)

--- a/TASVideos/ViewComponents/WikiModuleAttribute.cs
+++ b/TASVideos/ViewComponents/WikiModuleAttribute.cs
@@ -12,4 +12,9 @@ namespace TASVideos.ViewComponents
 
 		public string Name { get; }
 	}
+
+	[AttributeUsage(AttributeTargets.Class)]
+	public class TextModuleAttribute : Attribute
+	{
+	}
 }


### PR DESCRIPTION
This PR wires up a text version of wiki modules, to be implemented as needed.  Youtube is the current integration that needs a text only version.  This implements the frames module since publication descriptions are the target use case and the frames module is frequently used here.  Most other modules would be inappropriate in this situation and are hard to find examples in real descriptions.

The goal here is to set up a system where a text version of a module can easily be implemented as needed.