### PR TITLE
obsolete -> active + obsolete on Game pages

### DIFF
--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -62,9 +62,11 @@
 				<a href="/Movies-List-@(Model.Game.Id)G">
 					@Model.Game.PublicationCount Publications
 				</a>
-				(<a href="/Movies-List-@(Model.Game.Id)G-Obs">
-					@Model.Game.ObsoletePublicationCount Obsolete
-				</a>)
+				<span condition="Model.Game.ObsoletePublicationCount > 0">
+					(<a href="/Movies-List-@(Model.Game.Id)G-Obs">
+						@(Model.Game.PublicationCount + Model.Game.ObsoletePublicationCount) Total
+					</a>)
+				</span>
 			</li>
 			<li>
 				<a asp-page="PublicationHistory" asp-route-id="@Model.Game.Id">Publication History</a>


### PR DESCRIPTION
Same as #467 but on Game pages rather than User.

Could clarify further e.g. changing "Publications" to "Active Publications" but I think it's clear enough.

Also hides the parentheses if there are no obsolete movies.