### PR TITLE
Truncate game resources path in GameName module

### DIFF
--- a/TASVideos/ViewComponents/GameName.cs
+++ b/TASVideos/ViewComponents/GameName.cs
@@ -35,8 +35,9 @@ namespace TASVideos.ViewComponents
 			}
 			else
 			{
+				var baseGame = string.Join("/", path.Split('/').Take(3));
 				gameList = await _db.Games
-					.Where(g => g.GameResourcesPage == path)
+					.Where(g => g.GameResourcesPage == baseGame)
 					.Select(g => new GameNameModel
 					{
 						GameId = g.Id,


### PR DESCRIPTION
Fixes the display of the game name in subpages using GameResourcesHeader, e.g. https://demo.tasvideos.org/GameResources/NES/MikeTysonsPunchout/BaldBull1Strats