### PR TITLE
Clarify SeeEmails role description

### DIFF
--- a/TASVideos.Data/Entity/PermissionTo.cs
+++ b/TASVideos.Data/Entity/PermissionTo.cs
@@ -299,7 +299,7 @@ public enum PermissionTo
 	SeeDiagnostics = 9001,
 
 	[Group("Email")]
-	[Description("The ability to see user's emails")]
+	[Description("The ability to see a user's email address")]
 	SeeEmails = 9002
 
 	#endregion


### PR DESCRIPTION
Minor nit, "see user's emails" has a potential implication the role can see the user's actual emails, while all it actually does is show the user's email address.