### PR TITLE
Let Analyzers run on TASVideos.WikiEngine.Snapshots

### DIFF
--- a/TASVideos.Core/TASVideos.Core.csproj
+++ b/TASVideos.Core/TASVideos.Core.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<RunAnalyzers>true</RunAnalyzers>
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>

--- a/tests/TASVideos.WikiEngine.Snapshots/Program.cs
+++ b/tests/TASVideos.WikiEngine.Snapshots/Program.cs
@@ -5,9 +5,9 @@ using TASVideos.Data.Entity;
 using TASVideos.WikiEngine;
 using TASVideos.WikiEngine.AST;
 
-#if false
+/*
 namespace TASVideos.WikiEngine.Snapshots;
-#endif
+*/
 
 /*
 	1. Clone https://github.com/nattthebear/TASVideosWikiSnaps.git to somewhere

--- a/tests/TASVideos.WikiEngine.Snapshots/TASVideos.WikiEngine.Snapshots.csproj
+++ b/tests/TASVideos.WikiEngine.Snapshots/TASVideos.WikiEngine.Snapshots.csproj
@@ -10,7 +10,6 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<RunAnalyzers>false</RunAnalyzers> <!-- this project did not have StyleCop applied; when it was added, there were 2 extra warnings -->
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
The problem in the comment doesn't apply anymore.
Analyzers run for TASVideos.Core without it set explicitly.