### PR TITLE
Include source file paths as HTML comments in development environments

### DIFF
--- a/TASVideos/Extensions/ServiceCollectionExtensions.cs
+++ b/TASVideos/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using System.IO.Compression;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.ResponseCompression;
 using OpenTelemetry.Metrics;
@@ -86,6 +87,12 @@ public static class ServiceCollectionExtensions
 		if (env.IsDevelopment())
 		{
 			services.AddDatabaseDeveloperPageExceptionFilter();
+		}
+
+		if (env.ShouldIncludeSourceMappingComments())
+		{
+			services.AddSingleton<RazorPageActivator>();
+			services.AddSingleton<IRazorPageActivator, SelfIdentifyRazorPageActivator>();
 		}
 
 		services.AddResponseCaching();
@@ -210,4 +217,7 @@ public static class ServiceCollectionExtensions
 
 		return services;
 	}
+
+	public static bool ShouldIncludeSourceMappingComments(this IHostEnvironment env)
+		=> env.IsDevelopment();
 }

--- a/TASVideos/Pages/Shared/_Layout.cshtml
+++ b/TASVideos/Pages/Shared/_Layout.cshtml
@@ -1,5 +1,7 @@
 @using Microsoft.AspNetCore.Http
+﻿@using Microsoft.Extensions.Hosting
 @using TASVideos.Core.Services.Wiki
+@inject IHostEnvironment Env
 @inject IWikiPages WikiPages
 <!DOCTYPE html>
 <html lang="en">
@@ -154,7 +156,9 @@
 		@TempData["Message"]
 	</alert>
 	<div asp-validation-summary="ModelOnly" class="alert alert-danger alert-dismissible" role="alert"></div>
+	@if (Env.ShouldIncludeSourceMappingComments()) { <!--pause @ViewContext.ExecutingFilePath--> }
 	@RenderBody()
+	@if (Env.ShouldIncludeSourceMappingComments()) { <!--resume @ViewContext.ExecutingFilePath--> }
 	<hr/>
 	<footer class="mb-3">
 		<button id="button-scrolltop" class="d-none position-fixed px-3 py-1 m-2 bottom-0 end-0 btn btn-primary fa fa-caret-up"></button>

--- a/TASVideos/Services/SelfIdentifyRazorPageActivator.cs
+++ b/TASVideos/Services/SelfIdentifyRazorPageActivator.cs
@@ -1,0 +1,13 @@
+﻿using System.Web;
+using Microsoft.AspNetCore.Mvc.Razor;
+
+namespace TASVideos.Services;
+
+public sealed class SelfIdentifyRazorPageActivator(RazorPageActivator @base) : IRazorPageActivator
+{
+	public void Activate(IRazorPage page, ViewContext context)
+	{
+		context.Writer.Write($"<!--start {HttpUtility.HtmlEncode(context.ExecutingFilePath)}-->");
+		@base.Activate(page, context);
+	}
+}


### PR DESCRIPTION
Per https://github.com/TASVideos/tasvideos/issues/1845#issuecomment-2115759800, the general solution can only print at the start of files. Rather than manually add comments to the ends of files, I think selectively adding "pause"/"resume" around nested partials serves the same purpose with almost no work. This PR only adds that to the outermost partial, to be refined later.

The below examples are from the homepage and a publication page.
<img width="1750" height="825" alt="Screenshot from 2025-07-29 05-19-49" src="https://github.com/user-attachments/assets/dd014bb1-a64c-4e15-91ac-add9e16e93b6" />