### PR TITLE
Override synchronous `Process` in `AnchorTagHelper` subclasses

### DIFF
--- a/TASVideos/TagHelpers/Buttons/AddLinkTagHelper.cs
+++ b/TASVideos/TagHelpers/Buttons/AddLinkTagHelper.cs
@@ -6,14 +6,23 @@ namespace TASVideos.TagHelpers;
 
 public class AddLinkTagHelper(IHtmlGenerator generator) : AnchorTagHelper(generator)
 {
+	public override void Process(TagHelperContext context, TagHelperOutput output)
+	{
+		var task = output.GetChildContentAsync();
+		task.Wait();
+		SetOutput(context, output, task.Result.IsEmptyOrWhiteSpace);
+	}
+
 	public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+		=> SetOutput(context, output, (await output.GetChildContentAsync()).IsEmptyOrWhiteSpace);
+
+	private void SetOutput(TagHelperContext context, TagHelperOutput output, bool innerContentIsBlank)
 	{
 		output.TagName = "a";
-		await base.ProcessAsync(context, output);
+		base.Process(context, output);
 		output.AddCssClass("btn");
 		output.AddCssClass("btn-primary");
-		var content = (await output.GetChildContentAsync()).GetContent();
-		if (string.IsNullOrWhiteSpace(content))
+		if (innerContentIsBlank)
 		{
 			output.Content.AppendHtml("<i class=\"fa fa-plus\"></i> Add");
 		}

--- a/TASVideos/TagHelpers/Buttons/CancelLinkTagHelper.cs
+++ b/TASVideos/TagHelpers/Buttons/CancelLinkTagHelper.cs
@@ -8,7 +8,17 @@ public class CancelLinkTagHelper(IHtmlGenerator generator, IHttpContextAccessor 
 {
 	public string? BtnClassOverride { get; set; }
 
+	public override void Process(TagHelperContext context, TagHelperOutput output)
+	{
+		var task = output.GetChildContentAsync();
+		task.Wait();
+		SetOutput(context, output, task.Result.IsEmptyOrWhiteSpace);
+	}
+
 	public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+		=> SetOutput(context, output, (await output.GetChildContentAsync()).IsEmptyOrWhiteSpace);
+
+	private void SetOutput(TagHelperContext context, TagHelperOutput output, bool innerContentIsBlank)
 	{
 		output.TagName = "a";
 
@@ -24,15 +34,14 @@ public class CancelLinkTagHelper(IHtmlGenerator generator, IHttpContextAccessor 
 			RouteValues = new Dictionary<string, string>();
 		}
 
-		await base.ProcessAsync(context, output);
+		base.Process(context, output);
 		output.AddCssClass("btn");
 
 		output.AddCssClass(string.IsNullOrEmpty(BtnClassOverride)
 			? "btn-secondary"
 			: BtnClassOverride);
 
-		var content = (await output.GetChildContentAsync()).GetContent();
-		if (string.IsNullOrWhiteSpace(content))
+		if (innerContentIsBlank)
 		{
 			output.Content.AppendHtml("<i class=\"fa fa-times\"></i> Cancel");
 		}

--- a/TASVideos/TagHelpers/Buttons/EditLinkTagHelper.cs
+++ b/TASVideos/TagHelpers/Buttons/EditLinkTagHelper.cs
@@ -6,14 +6,23 @@ namespace TASVideos.TagHelpers;
 
 public class EditLinkTagHelper(IHtmlGenerator generator) : AnchorTagHelper(generator)
 {
+	public override void Process(TagHelperContext context, TagHelperOutput output)
+	{
+		var task = output.GetChildContentAsync();
+		task.Wait();
+		SetOutput(context, output, task.Result.IsEmptyOrWhiteSpace);
+	}
+
 	public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+		=> SetOutput(context, output, (await output.GetChildContentAsync()).IsEmptyOrWhiteSpace);
+
+	private void SetOutput(TagHelperContext context, TagHelperOutput output, bool innerContentIsBlank)
 	{
 		output.TagName = "a";
-		await base.ProcessAsync(context, output);
+		base.Process(context, output);
 		output.AddCssClass("btn");
 		output.AddCssClass("btn-primary");
-		var content = (await output.GetChildContentAsync()).GetContent();
-		if (string.IsNullOrWhiteSpace(content))
+		if (innerContentIsBlank)
 		{
 			output.Content.AppendHtml("<i class=\"fa fa-pencil\"></i> Edit");
 		}


### PR DESCRIPTION
See https://github.com/TASVideos/tasvideos/pull/2197#discussion_r2323773674 for explanation.
I've attempted to implement these 1) without simply calling `ProcessAsync` from `Process`, which adelikat didn't like, and 2) while minimising code duplication.