### PR TITLE
Fix submission message removing sync-verification happening too often

### DIFF
--- a/TASVideos/Pages/Submissions/Catalog.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Catalog.cshtml.cs
@@ -249,9 +249,12 @@ public class CatalogModel(ApplicationDbContext db, IExternalMediaPublisher publi
 			}
 			else
 			{
-				submission.SyncedOn = null;
-				submission.SyncedByUserId = null;
-				unsynced = true;
+				if (submission.SyncedOn.HasValue)
+				{
+					submission.SyncedOn = null;
+					submission.SyncedByUserId = null;
+					unsynced = true;
+				}
 			}
 		}
 


### PR DESCRIPTION
Resolves #2228 .
We only want to show the "unsynced" message if it was previously set.