### PR TITLE
Don't "announce" unpublications and submission removals, only post them regularly

### DIFF
--- a/TASVideos/Pages/Publications/Unpublish.cshtml.cs
+++ b/TASVideos/Pages/Publications/Unpublish.cshtml.cs
@@ -45,7 +45,7 @@ public class UnpublishModel(IExternalMediaPublisher publisher, IPublications pub
 				ErrorStatusMessage(result.ErrorMessage);
 				return RedirectToPage("View", new { Id });
 			case UnpublishResult.UnpublishStatus.Success:
-				await publisher.AnnounceUnpublish(result.PublicationTitle, Id, Reason);
+				await publisher.SendUnpublish(result.PublicationTitle, Id, Reason);
 				break;
 		}
 

--- a/TASVideos/Pages/Submissions/Delete.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Delete.cshtml.cs
@@ -42,7 +42,7 @@ public class DeleteModel(IQueueService queueService, IExternalMediaPublisher pub
 				ErrorStatusMessage(result.ErrorMessage);
 				return RedirectToPage("View", new { Id });
 			case DeleteSubmissionResult.DeleteStatus.Success:
-				await publisher.AnnounceSubmissionDelete(result.SubmissionTitle, Id);
+				await publisher.SendSubmissionDelete(result.SubmissionTitle, Id);
 				break;
 		}
 

--- a/TASVideos/Services/ExternalMediaPublisher.cs
+++ b/TASVideos/Services/ExternalMediaPublisher.cs
@@ -141,12 +141,11 @@ public static class ExternalMediaPublisherExtensions
 		});
 	}
 
-	public static async Task AnnounceUnpublish(this IExternalMediaPublisher publisher, string publicationTitle, int id, string reason)
+	public static async Task SendUnpublish(this IExternalMediaPublisher publisher, string publicationTitle, int id, string reason)
 	{
 		await publisher.Send(new Post
 		{
-			Announcement = $"{publicationTitle} REMOVED",
-			Type = PostType.Announcement,
+			Type = PostType.General,
 			Group = PostGroups.Publication,
 			Title = "Publication Removed",
 			FormattedTitle = "[Publication]({0}) Removed",
@@ -155,12 +154,11 @@ public static class ExternalMediaPublisherExtensions
 		});
 	}
 
-	public static async Task AnnounceSubmissionDelete(this IExternalMediaPublisher publisher, string submissionTitle, int id)
+	public static async Task SendSubmissionDelete(this IExternalMediaPublisher publisher, string submissionTitle, int id)
 	{
 		await publisher.Send(new Post
 		{
-			Announcement = $"{submissionTitle} REMOVED",
-			Type = PostType.Announcement,
+			Type = PostType.General,
 			Group = PostGroups.Submission,
 			Title = "Submission Removed",
 			FormattedTitle = "[Submission]({0}) Removed",


### PR DESCRIPTION
Resolves #2233 (because Bluesky only posts the things flagged as "Announcement").