### PR TITLE
Avoid adding Return URLs where they don't make sense

### DIFF
--- a/TASVideos/Pages/Account/Login.cshtml
+++ b/TASVideos/Pages/Account/Login.cshtml
@@ -33,7 +33,7 @@
 				<p>
 					Please view our <a href="/System/PrivacyPolicy">Privacy Policy</a><br/>
 					<a asp-page="ForgotPassword">Forgot your password?</a><br/>
-					<a asp-page="Register" asp-route-returnurl="@HttpContext.CurrentPathToReturnUrl()">Register as a new user?</a><br/>
+					<a asp-page="Register">Register as a new user?</a><br/>
 				</p>
 			</fieldset>
 		</form>

--- a/TASVideos/Pages/Shared/_LoginPartial.cshtml
+++ b/TASVideos/Pages/Shared/_LoginPartial.cshtml
@@ -8,6 +8,8 @@
 	{
 		notificationCount = await PrivateMessages.GetUnreadMessageCount(User.GetUserId());
 	}
+
+	bool returnAfterLogin = Context.Request.Path != "/Account/Login" && Context.Request.Path != "/Account/Register";
 }
 <navbar class="flex-wrap justify-content-end">
 	@if (isSignedIn)
@@ -44,7 +46,8 @@
 			<a class="nav-link" asp-page="/Account/Register">Register</a>
 		</nav-item>
 		<nav-item activate="Login">
-			<a class="nav-link text-nowrap" asp-page="/Account/Login" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()"><i class="fa fa-sign-in"></i> Log in</a>
+			<a condition="returnAfterLogin" class="nav-link text-nowrap" asp-page="/Account/Login" asp-route-returnUrl="@Context.CurrentPathToReturnUrl()"><i class="fa fa-sign-in"></i> Log in</a>
+			<a condition="!returnAfterLogin" class="nav-link text-nowrap" asp-page="/Account/Login"><i class="fa fa-sign-in"></i> Log in</a>
 		</nav-item>
 	}
 	<partial name="_Search" />


### PR DESCRIPTION
- Removes the return url when going from Login to Register.
- Removes the return url when on a Login or Register page and clicking the "Login" at the top again. This just keeps growing the return url and we get a lot of crawler requests who visit these unnecessary pages.