### PR TITLE
Fix handling of closing tags inside of noparse and code blocks.

### DIFF
--- a/TASVideos.ForumEngine/BbParser.cs
+++ b/TASVideos.ForumEngine/BbParser.cs
@@ -244,13 +244,7 @@ public partial class BbParser
 
 	private Element? FindMatchingForPop(string name)
 	{
-		var canPierce = true;
-		if (KnownTags.TryGetValue(_stack.Peek().Name, out var state) && state.Children == TagInfo.ChildrenAllowed.No)
-		{
-			canPierce = false;
-		}
-
-		if (canPierce)
+		if (ChildrenExpected())
 		{
 			return _stack.FirstOrDefault(elt => elt.Name == name);
 		}

--- a/tests/TASVideos.ForumEngineTests/BbParserTests.cs
+++ b/tests/TASVideos.ForumEngineTests/BbParserTests.cs
@@ -143,4 +143,24 @@ public class BbParserTests
 		var actual = await ParseBbcodeString(input);
 		Assert.AreEqual(expected, actual);
 	}
+
+	[TestMethod]
+	public async Task CloseConditionalChildYes()
+	{
+		const string input = "[b][url=http://foobar]wow[/b][/url]";
+		const string expected = "<b><a href=\"http://foobar\" rel=\"noopener external\">wow</a></b>[/url]";
+
+		var actual = await ParseBbcodeString(input);
+		Assert.AreEqual(expected, actual);
+	}
+
+	[TestMethod]
+	public async Task CloseConditionalChildNo()
+	{
+		const string input = "[b][url]http://foobar[/b][/url]";
+		const string expected = "<b><a href=\"http://foobar[/b]\" rel=\"noopener external\">http://foobar[/b]</a></b>";
+
+		var actual = await ParseBbcodeString(input);
+		Assert.AreEqual(expected, actual);
+	}
 }


### PR DESCRIPTION
Closes #2247.

Normally, child tags inside of `[noparse]` are ignored.  But when a closing tag matched an opening tag outside of the `[noparse]`, we still parsed it.  So in this instance, the `[/b]` would close the `[b]`, also closing the `[noparse]` inside of it, and leading to a mess:

```
[b][noparse]Hello [/b][/noparse]
```

The logic that allows closing tags to "skip over" other tags and close distant things was overly aggressive and should not have been applied here.  To fix this, we don't allow skipping over to close when inside a tag with no children allowed.  This is a breaking change, but the new behavior seems preferable.

I don't have a full localdev setup right now, so I tested this only with a few unit tests, covering both the case we want to fix, and one regression scenario that seemed important.

I also admit that I haven't written C# in a while, and am not up to date on much that's going on in this language 😬.  My brain is usually full of the Typescript that I get paid to write 😆.  So the code feels a bit awkward and probably doesn't use any of the new features appropriately.