### PR TITLE
VSCode: Update path from net8.0 to net10.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build_forumengine",
-			"program": "${workspaceRoot}/TASVideos.ForumEngineTempTest/bin/Debug/net8.0/TASVideos.ForumEngineTempTest.dll",
+			"program": "${workspaceRoot}/TASVideos.ForumEngineTempTest/bin/Debug/net10.0/TASVideos.ForumEngineTempTest.dll",
 			"args": [],
 			"cwd": "${workspaceRoot}",
 			"stopAtEntry": false,
@@ -20,7 +20,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build_wikiengine",
-			"program": "${workspaceRoot}/TASVideos.WikiEngineTest/bin/Debug/net8.0/TASVideos.WikiEngineTest.dll",
+			"program": "${workspaceRoot}/TASVideos.WikiEngineTest/bin/Debug/net10.0/TASVideos.WikiEngineTest.dll",
 			"args": [
 				"--force"
 			],
@@ -34,7 +34,7 @@
 			"request": "launch",
 			"preLaunchTask": "build",
 			// If you have changed target frameworks, make sure to update the program path.
-			"program": "${workspaceFolder}/TASVideos/bin/Debug/net8.0/TASVideos.dll",
+			"program": "${workspaceFolder}/TASVideos/bin/Debug/net10.0/TASVideos.dll",
 			"args": [],
 			"cwd": "${workspaceFolder}/TASVideos",
 			"stopAtEntry": false,
@@ -67,7 +67,7 @@
 			"request": "launch",
 			"preLaunchTask": "build",
 			// If you have changed target frameworks, make sure to update the program path.
-			"program": "${workspaceFolder}/TASVideos/bin/Debug/net8.0/TASVideos.dll",
+			"program": "${workspaceFolder}/TASVideos/bin/Debug/net10.0/TASVideos.dll",
 			"args": [],
 			"cwd": "${workspaceFolder}/TASVideos",
 			"stopAtEntry": false,
@@ -100,7 +100,7 @@
 			"request": "launch",
 			"preLaunchTask": "build",
 			// If you have changed target frameworks, make sure to update the program path.
-			"program": "${workspaceFolder}/TASVideos/bin/Debug/net8.0/TASVideos.dll",
+			"program": "${workspaceFolder}/TASVideos/bin/Debug/net10.0/TASVideos.dll",
 			"args": [],
 			"cwd": "${workspaceFolder}/TASVideos",
 			"stopAtEntry": false,


### PR DESCRIPTION
Tried building from VSCode and noticed the paths were outdated. I updated them locally and it worked. Sharing the update here for anybody also building with VSCode.