### PR TITLE
Fix API Pagination

### DIFF
--- a/TASVideos.Core/Paging/IPageable.cs
+++ b/TASVideos.Core/Paging/IPageable.cs
@@ -20,8 +20,8 @@ public static class PageableExtensions
 {
 	public static int Offset(this IPageable? pageable)
 	{
-		var current = Math.Max(pageable?.CurrentPage ?? 0, 1);
-		var size = Math.Max(pageable?.PageSize ?? 0, 1);
+		var current = Math.Max(pageable?.CurrentPage ?? 1, 1);
+		var size = Math.Max(pageable?.PageSize ?? 100, 1);
 		return (current - 1) * size;
 	}
 }


### PR DESCRIPTION
Fix pagination in api by updating default values for Core.IPagable.Offset to match default values from Api.Requests.ApiRequest

Fixes #2152 

E2E Test Summary:
> Test summary: total: 3684, failed: 0, succeeded: 3552, skipped: 132, duration: 38.1s