### PR TITLE
Disable rule SA1412 "Store files as UTF-8 with byte order mark"

### DIFF
--- a/Common.ruleset
+++ b/Common.ruleset
@@ -281,7 +281,7 @@
     <Rule Id="SA1401" Action="None" />
     <Rule Id="SA1402" Action="None" />
     <Rule Id="SA1408" Action="None" />
-    <Rule Id="SA1412" Action="Warning" />
+    <Rule Id="SA1412" Action="None" />
     <Rule Id="SA1413" Action="None" />
     <Rule Id="SA1502" Action="None" />
     <Rule Id="SA1516" Action="None" />


### PR DESCRIPTION
There is no reason to be using this backwards-compatibility feature in $CURRENTYEAR. So devs are getting their code flagged even if it's perfectly functional and readable, and the change asked of them is completely invisible, not even affecting whitespace.

I have not removed the BOMs from every file because it's not worth the time or effort.