### PR TITLE
Prevent changing rejection reason without permission

### DIFF
--- a/TASVideos/Extensions/EntityExtensions.cs
+++ b/TASVideos/Extensions/EntityExtensions.cs
@@ -117,6 +117,15 @@ public static class EntityExtensions
 			})
 			.ToListAsync();
 
+	public static List<SelectListItem> ToDropDownList(this IEnumerable<SubmissionRejectionReason> reasons)
+		=> [..reasons
+			.OrderBy(r => r.DisplayName)
+			.Select(r => new SelectListItem
+			{
+				Text = r.DisplayName,
+				Value = r.Id.ToString()
+			})];
+
 	public static Task<List<SelectListItem>> ToDropDownList(this IQueryable<GameSystemFrameRate> query, int systemId)
 		=> query
 			.ForSystem(systemId)

--- a/TASVideos/Pages/Submissions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Edit.cshtml.cs
@@ -286,7 +286,6 @@ public class EditModel(
 			&& (await queueService.CanDeleteSubmission(Id)).True;
 
 		AvailableClasses = await db.PublicationClasses.ToDropDownList();
-		AvailableRejectionReasons = await db.SubmissionRejectionReasons.ToDropDownList();
 
 		var subInfo = await db.Submissions
 			.Where(s => s.Id == Id)
@@ -295,12 +294,13 @@ public class EditModel(
 				RejectionReason = s.RejectionReason
 			})
 			.SingleOrDefaultAsync();
-		if (subInfo is not null)
+		if (subInfo is not null && subInfo.RejectionReason is not null && !User.Has(PermissionTo.RejectionReasonMaintenance))
 		{
-			if (subInfo.RejectionReason is not null && !User.Has(PermissionTo.RejectionReasonMaintenance))
-			{
-				AvailableRejectionReasons = await db.SubmissionRejectionReasons.Where(r => r.Id == subInfo.RejectionReason.Id).ToDropDownList();
-			}
+			AvailableRejectionReasons = new List<SubmissionRejectionReason> { subInfo.RejectionReason }.ToDropDownList();
+		}
+		else
+		{
+			AvailableRejectionReasons = await db.SubmissionRejectionReasons.ToDropDownList();
 		}
 	}
 


### PR DESCRIPTION
- Reject attempts to change rejection reason without correct permissions
- Filter dropdown for rejection reason based on status and permissions

Fixes #2243 

Specfically if the submission has been rejected and the current user lacks the RejectionReasonMaintenance permission the dropdown will only contain the current reason

Attempting to bypass this by manually fiddling with the request will also be rejected by the backend