### PR TITLE
When merging topics, adjust topic author when the first post of the topic changes as a result

### DIFF
--- a/TASVideos/Pages/Forum/Topics/Merge.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Merge.cshtml.cs
@@ -75,7 +75,22 @@ public class MergeModel(ApplicationDbContext db, IExternalMediaPublisher publish
 
 		var oldPosts = await db.ForumPosts
 			.ForTopic(Id)
+			.OrderBy(p => p.CreateTimestamp)
 			.ToListAsync();
+
+		var firstPostOldTopic = oldPosts.FirstOrDefault();
+		if (firstPostOldTopic is not null)
+		{
+			var firstPostDestinationTopic = await db.ForumPosts
+				.ForTopic(Topic.DestinationTopicId)
+				.OrderBy(p => p.CreateTimestamp)
+				.FirstOrDefaultAsync();
+
+			if (firstPostDestinationTopic is not null && firstPostOldTopic.CreateTimestamp < firstPostDestinationTopic.CreateTimestamp)
+			{
+				destinationTopic.PosterId = firstPostOldTopic.PosterId;
+			}
+		}
 
 		foreach (var post in oldPosts)
 		{

--- a/tests/TASVideos.RazorPages.Tests/Pages/Forum/Topics/MergeModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Forum/Topics/MergeModelTests.cs
@@ -295,4 +295,38 @@ public class MergeModelTests : BasePageModelTests
 		Assert.AreEqual(destinationTopic.Id, post.TopicId);
 		Assert.AreEqual(targetForum.Id, post.ForumId);
 	}
+
+	[TestMethod]
+	public async Task OnPost_MergeOlderIntoNewer_UpdatesPoster()
+	{
+		var originalUser = _db.AddUser("OriginalUser").Entity;
+		var originalTopic = _db.AddTopic(originalUser).Entity;
+		originalTopic.Title = "Original Topic";
+		var originalPost = _db.CreatePostForTopic(originalTopic, originalUser).Entity;
+		originalTopic.Poster = originalPost.Poster;
+
+		var destinationUser = _db.AddUser("DestinationUser").Entity;
+		var destinationTopic = _db.AddTopic(destinationUser).Entity;
+		destinationTopic.Title = "Destination Topic";
+		var destinationPost = _db.CreatePostForTopic(destinationTopic, destinationUser).Entity;
+		destinationTopic.Poster = destinationPost.Poster;
+
+		originalPost.CreateTimestamp = destinationPost.CreateTimestamp.AddHours(-1);
+		await _db.SaveChangesAsync();
+
+		AddAuthenticatedUser(_model, originalUser, [PermissionTo.MergeTopics]);
+		_model.Id = originalTopic.Id;
+		_model.Topic = new MergeModel.TopicMerge
+		{
+			DestinationTopicId = destinationTopic.Id,
+			Title = originalTopic.Title,
+			ForumId = originalTopic.ForumId,
+			ForumName = originalTopic.Forum!.Name
+		};
+
+		var result = await _model.OnPost();
+
+		AssertRedirect(result, "Index");
+		Assert.AreEqual(destinationTopic.PosterId, originalPost.PosterId);
+	}
 }


### PR DESCRIPTION
Resolves #2167 .

Someone could have a point that just because someone has the first post, they shouldn't automatically be the topic author. But I don't think any of our moderation team knows about this or cares that there was a difference between merging topic A into B or merging B into A.
If we want to isolate the concept of "Topic Poster" from "First post of topic" then we should make the Topic Poster properly editable by the moderation team in all relevant edit pages.