### PR TITLE
Update MailKit (and MimeKit)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="JavaScriptEngineSwitcher.V8" Version="3.29.1" />
     <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.477" />
     <PackageVersion Include="LigerShark.WebOptimizer.Sass" Version="3.0.143" />
-    <PackageVersion Include="MailKit" Version="4.14.1" />
+    <PackageVersion Include="MailKit" Version="4.15.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.2" />


### PR DESCRIPTION
Update the version due to the medium severity vulnerability in the previous version ( https://github.com/advisories/GHSA-g7hc-96xr-gvvx ), which causes annoying (but important) warning messages every time the solution is built.

Looking at it, we're not really affected. The issue is potential `\r` and `\n` characters somewhere in email addresses. We use the `[EmailAddress]` attribute for email input field validation, and it rejects any email address containing those characters.