### PR TITLE
Fix consecutive `float`'d images

### DIFF
--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -206,17 +206,17 @@ body {
 	border: 0;
 
 	&left {
-		margin-right: 10px;
+		margin-inline-end: 10px;
 		border: 0;
-		clear: left;
-		float: left;
+		clear: inline-start;
+		float: inline-start;
 	}
 
 	&right {
-		margin-left: 10px;
+		margin-inline-start: 10px;
 		border: 0;
-		clear: right;
-		float: right;
+		clear: inline-end;
+		float: inline-end;
 	}
 }
 


### PR DESCRIPTION
without `clear`
<img width="1051" height="904" alt="Screenshot from 2026-03-15 12-20-35" src="https://github.com/user-attachments/assets/380a0343-7d7c-4267-8aef-4384858b97cf" />
with `clear`
<img width="1051" height="904" alt="Screenshot from 2026-03-15 12-20-42" src="https://github.com/user-attachments/assets/c5577998-4d55-496d-a86f-17111f278c2d" />