### PR TITLE
Further distinguish hyperlinks and submenus (non-hyperlinks) in the navbar

### DIFF
--- a/TASVideos/TagHelpers/NavbarTagHelpers.cs
+++ b/TASVideos/TagHelpers/NavbarTagHelpers.cs
@@ -51,7 +51,7 @@ public class NavDropdownTagHelper : NavItemBase
 		}
 
 		output.Content.SetHtmlContent(
-			$"<a href='#' class='{addClass}' data-bs-toggle='dropdown'>{Name ?? ""}<span class='caret'></span></a>");
+			$"<a href='#' class='{addClass}' data-bs-toggle='dropdown'>{Name ?? ""}</a>");
 
 		output.Content.AppendHtml($"<div class='dropdown-menu'>{content}</div>");
 	}

--- a/TASVideos/TagHelpers/NavbarTagHelpers.cs
+++ b/TASVideos/TagHelpers/NavbarTagHelpers.cs
@@ -51,7 +51,7 @@ public class NavDropdownTagHelper : NavItemBase
 		}
 
 		output.Content.SetHtmlContent(
-			$"<a href='#' class='{addClass}' data-bs-toggle='dropdown'>{Name ?? ""}</a>");
+			$"<button class='{addClass}' data-bs-toggle='dropdown'>{Name ?? ""}</button>");
 
 		output.Content.AppendHtml($"<div class='dropdown-menu'>{content}</div>");
 	}

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -168,6 +168,17 @@ button.nav-link:hover {
 	text-decoration: underline dashed;
 }
 
+.nav-link.dropdown-toggle {
+	/** these are the little arrows (drawn with borders!) */
+	&::after {
+		transform: scaleX(1.15) scaleY(1.15);
+		vertical-align: 0;
+	}
+	&[aria-expanded="true"]::after {
+		transform: scaleX(1.15) scaleY(-1.15);
+	}
+}
+
 .breadcrumb-item {
 	font-size: 1.25em;
 	line-height: 1.25em;

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -163,6 +163,11 @@ h4 {
 	color: RGBA(255,255,255,.6);
 }
 
+/** to complement the underline on `a.nav-link` (all hyperlinks actually) */
+button.nav-link:hover {
+	text-decoration: underline dashed;
+}
+
 .breadcrumb-item {
 	font-size: 1.25em;
 	line-height: 1.25em;

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -179,6 +179,11 @@ button.nav-link:hover {
 	}
 }
 
+/** `.dropdown-item` overrides the weight otherwise; this is seen in the navbar */
+.fw-bold .dropdown-item {
+	font-weight: 600;
+}
+
 .breadcrumb-item {
 	font-size: 1.25em;
 	line-height: 1.25em;


### PR DESCRIPTION
Follow-up to #2283, though the earlier iterations of the navbar suffered more or less from the same problem.
Live site:
<img width="1093" height="194" alt="Screenshot_20260317_134310" src="https://github.com/user-attachments/assets/8a9ca101-1b48-44f2-afed-8542e3e4878f" />
With this changeset:
<img width="1093" height="194" alt="Screenshot_20260317_134329" src="https://github.com/user-attachments/assets/663a3b21-2f2b-4926-b04d-af87c5832786" />
The arrows are slightly larger and on the baseline, and for desktop users, the hover effect is a dashed line instead of solid because I couldn't think of anything else.

Other changes I considered but have not included:
- italics for submenus (looked bad IMO)
- `cursor: context-menu;` for submenus (I think it's intended only for context menus? also it would only help desktop users, and they already have the underline on hover)
- even higher `font-weight` for hyperlinks / lower `font-weight` for submenus (it would need to be like 500 vs 800 to be distinct, which looked bad IMO)
- drop shadows (might help since the contrast is a bit low, but the `color` isn't fully opaque so a naive implementation won't work)