### PR TITLE
Make gzm parser fail faster on errors

### DIFF
--- a/TASVideos.Parsers/Parsers/Gzm.cs
+++ b/TASVideos.Parsers/Parsers/Gzm.cs
@@ -44,19 +44,22 @@ internal class Gzm : Parser, IParser
 			var ocaSync = (int)BinaryPrimitives.ReverseEndianness(reader.ReadUInt32());
 			var roomLoad = (int)BinaryPrimitives.ReverseEndianness(reader.ReadUInt32());
 
+			var ocaInputBuffer = new byte[8];
 			for (var a = 0; a < ocaInput; a++)
 			{
-				reader.ReadBytes(8);
+				reader.ReadExactly(ocaInputBuffer);
 			}
 
+			var ocaSyncBuffer = new byte[8];
 			for (var a = 0; a < ocaSync; a++)
 			{
-				reader.ReadBytes(8);
+				reader.ReadExactly(ocaSyncBuffer);
 			}
 
+			var roomLoadBuffer = new byte[4];
 			for (var a = 0; a < roomLoad; a++)
 			{
-				reader.ReadBytes(4);
+				reader.ReadExactly(roomLoadBuffer);
 			}
 
 			result.RerecordCount = (int)BinaryPrimitives.ReverseEndianness(reader.ReadUInt32());


### PR DESCRIPTION
ReadBytes will not throw an exception on file end, but ReadExactly will.
This cuts down the test duration from 3 minutes to under 1 second.

This is the reason it took 3 minutes previously. The for-loop still happens with the big value, but it now fails as soon as the entire file is parsed to the end.
<img width="412" height="83" alt="image" src="https://github.com/user-attachments/assets/0edd0e30-2f79-4eb3-a1de-290e4223ebaf" />
