### PR TITLE
Adjust User IP Page

### DIFF
--- a/TASVideos/Pages/Users/Ips.cshtml
+++ b/TASVideos/Pages/Users/Ips.cshtml
@@ -7,7 +7,8 @@
 		.Select(i => new { Ip = i.Key, UsedOn = i.Max(ii => ii.UsedOn) })
 		.ToList();
 }
-<fullrow>This list shows IP addresses the user used for forum posts and forum poll votes.</fullrow>
+<fullrow permission="BanIpAddresses"><a asp-page="/Users/IpBan">View existing IP bans.</a></fullrow>
+<fullrow>The following list shows IP addresses the user used for forum posts and forum poll votes.</fullrow>
 <standard-table>
 	<caption>Total: @ipList.Count</caption>
 	<table-head columns="IP Address,Last Used,"></table-head>
@@ -17,7 +18,7 @@
 			<td>@ip.Ip</td>
 			<td><timezone-convert asp-for="@ip.UsedOn" /></td>
 			<td>
-				<a permission="BanIpAddresses" asp-page="/Users/IpBan" asp-route-banIp="@ip" class="btn btn-danger">Ban</a>
+				<a permission="BanIpAddresses" asp-page="/Users/IpBan" asp-route-banIp="@ip.Ip" class="btn btn-danger">Ban</a>
 			</td>
 		</tr>
 	}

--- a/TASVideos/Pages/Users/Ips.cshtml
+++ b/TASVideos/Pages/Users/Ips.cshtml
@@ -7,7 +7,7 @@
 		.Select(i => new { Ip = i.Key, UsedOn = i.Max(ii => ii.UsedOn) })
 		.ToList();
 }
-
+<fullrow>This list shows IP addresses the user used for forum posts and forum poll votes.</fullrow>
 <standard-table>
 	<caption>Total: @ipList.Count</caption>
 	<table-head columns="IP Address,Last Used,"></table-head>

--- a/TASVideos/Pages/Users/Ips.cshtml.cs
+++ b/TASVideos/Pages/Users/Ips.cshtml.cs
@@ -19,7 +19,7 @@ public class IpsModel(ApplicationDbContext db) : BasePageModel
 		var postIps = await db.ForumPosts
 			.Where(p => p.PosterId == user.Id)
 			.Where(p => p.IpAddress != null)
-			.Select(p => new IpEntry(p.IpAddress ?? "", p.PostEditedTimestamp ?? p.LastUpdateTimestamp))
+			.Select(p => new IpEntry(p.IpAddress ?? "", p.PostEditedTimestamp ?? p.CreateTimestamp))
 			.Distinct()
 			.ToListAsync();
 


### PR DESCRIPTION
This adds an explanation what the listed IPs even are.
It also uses the CreateTimestamp as a fallback for when the PostEditedTimestamp doesn't exist. The reason is that the old LastUpdateTimestamp is updated by operations unrelated to the IP, such as when posts are moved by moderators.

(The reason it was there in the first place is because the old site data edit timestamps were imported into the LastUpdateTimestamp, a bit of a logic error, because we don't want moving posts to show up as "edited".)

Edit: I also added a link to the existing IP bans list, and also fixes a bug with the "Ban" button.