### PR TITLE
Allow case-renaming Wiki pages (via wiki move)

### DIFF
--- a/TASVideos.Core/Services/Wiki/WikiPages.cs
+++ b/TASVideos.Core/Services/Wiki/WikiPages.cs
@@ -100,6 +100,12 @@ public interface IWikiPages
 	/// <param name="authorId">The ID of the user performing the rollback</param>
 	/// <returns>The new revision created by the rollback, or null if rollback failed</returns>
 	Task<IWikiPage?> RollbackLatest(string pageName, int authorId);
+
+	/// <summary>
+	/// Returns whether a page can be moved to a different page name.
+	/// Moves are only allowed if the new page does not exist or is the same page as the old page.
+	/// </summary>
+	Task<bool> CanMove(string oldPageName, string newPageName);
 }
 
 // TODO: handle DbConcurrency exceptions
@@ -280,9 +286,9 @@ internal class WikiPages(ApplicationDbContext db, ICacheService cache) : IWikiPa
 
 		// TODO: support moving a page to a deleted page
 		// Revision ids would have to be adjusted, but it could be done
-		if (await Exists(destinationName, includeDeleted: true))
+		if (!await CanMove(originalName, destinationName))
 		{
-			throw new InvalidOperationException($"Cannot move {originalName} to {destinationName} because {destinationName} already exists.");
+			throw new InvalidOperationException($"Cannot move {originalName} to {destinationName} because either {originalName} does not exist, or {destinationName} already exists or has an invalid format.");
 		}
 
 		var existingRevisions = await db.WikiPages
@@ -609,6 +615,24 @@ internal class WikiPages(ApplicationDbContext db, ICacheService cache) : IWikiPa
 		};
 
 		return await Add(rollbackRevision);
+	}
+
+	public async Task<bool> CanMove(string oldPageName, string newPageName)
+	{
+		oldPageName = oldPageName.Trim('/');
+		newPageName = newPageName.Trim('/');
+		if (!WikiHelper.IsValidWikiPageName(newPageName))
+		{
+			return false;
+		}
+
+		var pages = await db.WikiPages
+			.ThatAreCurrent()
+			.Select(wp => wp.PageName)
+			.Where(pageName => pageName == oldPageName || pageName == newPageName)
+			.ToListAsync();
+
+		return pages.Count == 1 && pages[0] == oldPageName;
 	}
 }
 

--- a/TASVideos/Pages/Wiki/Move.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Move.cshtml.cs
@@ -41,9 +41,9 @@ public class MoveModel(IWikiPages wikiPages, IExternalMediaPublisher publisher) 
 		OriginalPageName = OriginalPageName.Trim('/');
 		DestinationPageName = DestinationPageName.Trim('/');
 
-		if (await wikiPages.Exists(DestinationPageName, includeDeleted: true))
+		if (!await wikiPages.CanMove(OriginalPageName, DestinationPageName))
 		{
-			ModelState.AddModelError("DestinationPageName", "The destination page already exists.");
+			ModelState.AddModelError("", "Either the original page does not exist, or the destination page already exists or has an invalid format.");
 		}
 
 		if (!ModelState.IsValid)

--- a/tests/TASVideos.Core.Tests/Services/WikiPagesTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/WikiPagesTests.cs
@@ -576,8 +576,7 @@ public class WikiPagesTests : TestDbBase
 	[TestMethod]
 	public async Task Move_OriginalDoesNotExist_NothingHappens()
 	{
-		var actual = await _wikiPages.Move("Does not exist", "Also does not exist", 1);
-		Assert.IsTrue(actual, "Page not found is considered successful");
+		await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => _wikiPages.Move("Does not exist", "Also does not exist", 1));
 		Assert.AreEqual(0, _db.WikiPages.Count());
 		Assert.IsEmpty(_cache.PageCache());
 	}
@@ -1966,5 +1965,60 @@ public class WikiPagesTests : TestDbBase
 		}
 
 		return wp.Id;
+	}
+
+	[TestMethod]
+	public async Task CanMove_DestinationDoesNotExist_ReturnsTrue()
+	{
+		const string sourcePage = "Source";
+		const string destinationPage = "Destination";
+		AddPage(sourcePage);
+
+		var actual = await _wikiPages.CanMove(sourcePage, destinationPage);
+		Assert.IsTrue(actual);
+	}
+
+	[TestMethod]
+	public async Task CanMove_DestinationAlreadyExists_ReturnsFalse()
+	{
+		const string sourcePage = "Source";
+		const string destinationPage = "Destination";
+		AddPage(sourcePage);
+		AddPage(destinationPage);
+
+		var actual = await _wikiPages.CanMove(sourcePage, destinationPage);
+		Assert.IsFalse(actual);
+	}
+
+	[TestMethod]
+	public async Task CanMove_DestinationIsSameAsSource_ReturnsTrue()
+	{
+		const string sourcePage = "Source";
+		const string destinationPage = "SOURCE";
+		AddPage(sourcePage);
+
+		var actual = await _wikiPages.CanMove(sourcePage, destinationPage);
+		Assert.IsTrue(actual);
+	}
+
+	[TestMethod]
+	public async Task CanMove_OnlyDestinationExists_ReturnsFalse()
+	{
+		const string sourcePage = "Source";
+		const string destinationPage = "Destination";
+		AddPage(destinationPage);
+
+		var actual = await _wikiPages.CanMove(sourcePage, destinationPage);
+		Assert.IsFalse(actual);
+	}
+
+	[TestMethod]
+	public async Task CanMove_NoPagesExist_ReturnsFalse()
+	{
+		const string sourcePage = "Source";
+		const string destinationPage = "Destination";
+
+		var actual = await _wikiPages.CanMove(sourcePage, destinationPage);
+		Assert.IsFalse(actual);
 	}
 }

--- a/tests/TASVideos.RazorPages.Tests/Pages/Wiki/MoveModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Wiki/MoveModelTests.cs
@@ -86,18 +86,18 @@ public class MoveModelTests : TestDbBase
 	}
 
 	[TestMethod]
-	public async Task OnPost_DestinationPageExists_AddsModelErrorAndReturnsPage()
+	public async Task OnPost_CanMoveReturnsFalse_AddsModelErrorAndReturnsPage()
 	{
 		_model.OriginalPageName = "TestPage";
 		_model.DestinationPageName = "ExistingPage";
-		_wikiPages.Exists("ExistingPage", includeDeleted: true).Returns(true);
+		_wikiPages.CanMove("TestPage", "ExistingPage").Returns(false);
 
 		var result = await _model.OnPost();
 
 		Assert.IsInstanceOfType<PageResult>(result);
 		Assert.IsFalse(_model.ModelState.IsValid);
-		Assert.IsNotNull(_model.ModelState["DestinationPageName"]);
-		Assert.IsTrue(_model.ModelState["DestinationPageName"]!.Errors.Any(e => e.ErrorMessage.Contains("already exists")));
+		Assert.IsNotNull(_model.ModelState[""]);
+		Assert.IsTrue(_model.ModelState[""]!.Errors.Any(e => e.ErrorMessage.Contains("already exists")));
 		await _wikiPages.DidNotReceive().Move(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>());
 	}
 
@@ -109,7 +109,7 @@ public class MoveModelTests : TestDbBase
 		AddAuthenticatedUser(_model, user, [PermissionTo.MoveWikiPages]);
 		_model.OriginalPageName = "/TestPage/";
 		_model.DestinationPageName = "/NewPage/";
-		_wikiPages.Exists("NewPage", includeDeleted: true).Returns(false);
+		_wikiPages.CanMove("TestPage", "NewPage").Returns(true);
 		_wikiPages.Move("TestPage", "NewPage", user.Id).Returns(true);
 
 		var result = await _model.OnPost();
@@ -126,7 +126,7 @@ public class MoveModelTests : TestDbBase
 		AddAuthenticatedUser(_model, user, [PermissionTo.MoveWikiPages]);
 		_model.OriginalPageName = "OriginalPage";
 		_model.DestinationPageName = "DestinationPage";
-		_wikiPages.Exists("DestinationPage", includeDeleted: true).Returns(false);
+		_wikiPages.CanMove("OriginalPage", "DestinationPage").Returns(true);
 		_wikiPages.Move("OriginalPage", "DestinationPage", user.Id).Returns(true);
 
 		var result = await _model.OnPost();
@@ -146,7 +146,7 @@ public class MoveModelTests : TestDbBase
 		AddAuthenticatedUser(_model, user, [PermissionTo.MoveWikiPages]);
 		_model.OriginalPageName = "TestPage";
 		_model.DestinationPageName = "NewPage";
-		_wikiPages.Exists("NewPage", includeDeleted: true).Returns(false);
+		_wikiPages.CanMove("TestPage", "NewPage").Returns(true);
 		_wikiPages.Move("TestPage", "NewPage", user.Id).Returns(false);
 
 		var result = await _model.OnPost();


### PR DESCRIPTION
We already use the same logic with user renames, see #2073 .
Basically, we query the DB for both old and new page, and it must return one and only one page for renames to be allowed.