### PR TITLE
Minor UI fixes

### DIFF
--- a/TASVideos/Pages/Submissions/Edit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Edit.cshtml.cs
@@ -246,7 +246,7 @@ public class EditModel(
 		}
 
 		var result = await queueService.ClaimForJudging(Id, User.GetUserId(), User.Name());
-		SetMessage(result.Success, "", result.ErrorMessage ?? "Unable to claim");
+		SetMessage(result.Success, "Successfully claimed for judging.", result.ErrorMessage ?? "Unable to claim");
 
 		if (result.Success)
 		{
@@ -264,7 +264,7 @@ public class EditModel(
 		}
 
 		var result = await queueService.ClaimForPublishing(Id, User.GetUserId(), User.Name());
-		SetMessage(result.Success, "", result.ErrorMessage ?? "Unable to claim");
+		SetMessage(result.Success, "Successfully claimed for publishing.", result.ErrorMessage ?? "Unable to claim");
 
 		if (result.Success)
 		{

--- a/TASVideos/Pages/Wiki/PageDoesNotExist.cshtml
+++ b/TASVideos/Pages/Wiki/PageDoesNotExist.cshtml
@@ -6,8 +6,8 @@
 	HttpContext.Response.StatusCode = 404;
 }
 <h2>The page you were looking for does not yet exist.</h2>
-<p>The page ( <a href="/@url">@($"{HttpContext.Request.ToBaseUrl()}/{url}")</a> ) does not exist. <a href="javascript:history.back()">Click here</a> to go back.</p>
-<p>You can also <a asp-page="/Search/Index" asp-route-searchTerms="@url">search</a> for alternative titles or spellings.</p>
+<p>The page ( <a href="/@url">@($"{HttpContext.Request.ToBaseUrl()}/{url}")</a> ) does not exist.</p>
+<p>You can <a asp-page="/Search/Index" asp-route-searchTerms="@url">search</a> for alternative titles or spellings.</p>
 <hr />
 Want to create the page?
 <br />

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -655,8 +655,10 @@ fieldset {
 .action-column {
 	display: flex;
 	gap: 4px;
-	& > * {
-		text-wrap: nowrap;
+	text-wrap: nowrap;
+
+	& .modal {
+		text-wrap: initial;
 	}
 }
 


### PR DESCRIPTION
Removes the back button introduced in #1544 because it doesn't work anymore due to our content security policy (no inline javascript).
We don't want history.back() anyway, see https://github.com/TASVideos/tasvideos/issues/2054#issuecomment-2519701632 for reasons.

Also confirmation dialogs from action column buttons had a broken layout because their DOM tree is inside the button itself and that had `text-wrap: nowrap`. So this undoes that inside the modal.

Also resolves #2294 .