### PR TITLE
Fix System editing

### DIFF
--- a/TASVideos/Pages/Systems/Create.cshtml
+++ b/TASVideos/Pages/Systems/Create.cshtml
@@ -26,7 +26,6 @@
 	</row>
 	<form-button-bar>
 		<submit-button edit="false"></submit-button>
-		<submit-button></submit-button>
 		<cancel-link asp-page="Index"></cancel-link>
 	</form-button-bar>
 </form>

--- a/TASVideos/Pages/Systems/Edit.cshtml
+++ b/TASVideos/Pages/Systems/Edit.cshtml
@@ -38,18 +38,21 @@
 </top-button-bar>
 <standard-table>
 	<table-head columns="Framerate,Region,Preliminary,Obsolete,Actions"></table-head>
-	@foreach (var rate in Model.System.SystemFrameRates
-		.OrderBy(r => r.Obsolete)
-		.ThenBy(r => r.FrameRate))
+	@if (Model.SystemFrameRates is not null)
 	{
-		<tr class="@(rate.Obsolete ? "table-info" : "")">
-			<td>@rate.FrameRate</td>
-			<td>@rate.RegionCode</td>
-			<td>@rate.Preliminary</td>
-			<td>@rate.Obsolete</td>
-			<td-action-column>
-				<edit-link class="btn-sm" asp-page="EditFrameRate" asp-route-id="@rate.Id"></edit-link>
-			</td-action-column>
-		</tr>
+		@foreach (var rate in Model.SystemFrameRates
+			.OrderBy(r => r.Obsolete)
+			.ThenBy(r => r.FrameRate))
+		{
+			<tr class="@(rate.Obsolete ? "table-info" : "")">
+				<td>@rate.FrameRate</td>
+				<td>@rate.RegionCode</td>
+				<td>@rate.Preliminary</td>
+				<td>@rate.Obsolete</td>
+				<td-action-column>
+					<edit-link class="btn-sm" asp-page="EditFrameRate" asp-route-id="@rate.Id"></edit-link>
+				</td-action-column>
+			</tr>
+		}
 	}
 </standard-table>

--- a/TASVideos/Pages/Systems/Edit.cshtml.cs
+++ b/TASVideos/Pages/Systems/Edit.cshtml.cs
@@ -7,7 +7,9 @@ public class EditModel(IGameSystemService systemService) : BasePageModel
 	public int Id { get; set; }
 
 	[BindProperty]
-	public SystemsResponse System { get; set; } = null!;
+	public SystemsEditModel System { get; set; } = null!;
+
+	public IEnumerable<FrameRatesResponse>? SystemFrameRates { get; set; }
 
 	public bool InUse { get; set; } = true;
 
@@ -19,7 +21,8 @@ public class EditModel(IGameSystemService systemService) : BasePageModel
 			return NotFound();
 		}
 
-		System = system;
+		System = new SystemsEditModel(system.Id, system.Code, system.DisplayName);
+		SystemFrameRates = system.SystemFrameRates;
 		InUse = await systemService.InUse(Id);
 		return Page();
 	}
@@ -73,3 +76,5 @@ public class EditModel(IGameSystemService systemService) : BasePageModel
 		return BasePageRedirect("Index");
 	}
 }
+
+public record SystemsEditModel(int Id, string Code, string DisplayName);

--- a/tests/TASVideos.RazorPages.Tests/Pages/Systems/EditModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Systems/EditModelTests.cs
@@ -15,7 +15,8 @@ public class EditModelTests : BasePageModelTests
 		_model = new EditModel(_systemService)
 		{
 			PageContext = TestPageContext(),
-			System = new(123, "NES", "Nintendo", [new FrameRatesResponse(456, 60, "NTSC", true, true)])
+			System = new(123, "NES", "Nintendo"),
+			SystemFrameRates = [new FrameRatesResponse(456, 60, "NTSC", true, true)],
 		};
 	}
 


### PR DESCRIPTION
System editing was fully broken.

We ran into two simultaneous bugs here, originating from the commit that converted a lot of classes into records.

First bug: The original bound property (with [BindProperty]) was a `SystemsResponse`, which was a record with an IEnumerable inside. In the .cshtml we didn't even put the IEnumerable into a form, so the model binder just set it to null. In the OnPost the model was then invalid because that field was "required".

Second bug: The OnPost model is invalid, so it tries to return the page. However, the model binder set the non-nullable IEnumerable to null (which might be a big downside to using records). The .cshtml tries to iterate the null value and crashes.

I fixed these bugs by making a new record type just for the editing flow, and putting the IEnumerable separately.

(Btw, technically we still have a third bug: After OnPost returns, the page loses the information about the "InUse" and "SystemFrameRates" properties. But that's non-critical, and I don't know how to best fix that anyway.)