### PR TITLE
Add basic wiki redirects

### DIFF
--- a/TASVideos.Data/ApplicationDbContext.cs
+++ b/TASVideos.Data/ApplicationDbContext.cs
@@ -28,6 +28,7 @@ public class ApplicationDbContext : IdentityDbContext<User, Role, int, UserClaim
 	public DbSet<RolePermission> RolePermission { get; set; } = null!;
 	public DbSet<WikiPage> WikiPages { get; set; } = null!;
 	public DbSet<WikiPageReferral> WikiReferrals { get; set; } = null!;
+	public DbSet<WikiRedirect> WikiRedirects { get; set; } = null!;
 	public DbSet<RoleLink> RoleLinks { get; set; } = null!;
 	public DbSet<Submission> Submissions { get; set; } = null!;
 	public DbSet<SubmissionAuthor> SubmissionAuthors { get; set; } = null!;

--- a/TASVideos.Data/Entity/PermissionTo.cs
+++ b/TASVideos.Data/Entity/PermissionTo.cs
@@ -86,6 +86,10 @@ public enum PermissionTo
 	[Description("The ability to see wiki pages/revisions that were deleted.")]
 	SeeDeletedWikiPages = 106,
 
+	[Group("Wiki")]
+	[Description("The ability to create and edit wiki redirects.")]
+	EditWikiRedirects = 107,
+
 	[Group("Wiki Administration")]
 	[Description("(Not used, do not assign), Was the ability to see certain restricted pages that pertain to administration activities. There are no pages that meet this criteria.")]
 	SeeAdminPages = 190,

--- a/TASVideos.Data/Entity/WikiRedirect.cs
+++ b/TASVideos.Data/Entity/WikiRedirect.cs
@@ -1,0 +1,12 @@
+using TASVideos.Data.AutoHistory;
+
+namespace TASVideos.Data.Entity;
+
+[IncludeInAutoHistory]
+[Index(nameof(PageNameFrom), IsUnique = true)]
+public class WikiRedirect : BaseEntity
+{
+	public int Id { get; set; }
+	public string PageNameFrom { get; set; } = "";
+	public string PageNameTo { get; set; } = "";
+}

--- a/TASVideos.Data/Migrations/20260430183837_AddWikiRedirects.Designer.cs
+++ b/TASVideos.Data/Migrations/20260430183837_AddWikiRedirects.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430183837_AddWikiRedirects")]
+    partial class AddWikiRedirects
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20260430183837_AddWikiRedirects.cs
+++ b/TASVideos.Data/Migrations/20260430183837_AddWikiRedirects.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWikiRedirects : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "wiki_redirects",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    page_name_from = table.Column<string>(type: "citext", nullable: false),
+                    page_name_to = table.Column<string>(type: "citext", nullable: false),
+                    create_timestamp = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    last_update_timestamp = table.Column<DateTime>(type: "timestamp without time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_wiki_redirects", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_wiki_redirects_page_name_from",
+                table: "wiki_redirects",
+                column: "page_name_from",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "wiki_redirects");
+        }
+    }
+}

--- a/TASVideos/Pages/Shared/_NavBarPartial.cshtml
+++ b/TASVideos/Pages/Shared/_NavBarPartial.cshtml
@@ -47,6 +47,7 @@
 		<a class="dropdown-item" href="/TODO">To Do</a>
 		<a class="dropdown-item" href="/System">System Pages</a>
 		<a permission="SeeDeletedWikiPages" asp-page="/Wiki/DeletedPages" class="dropdown-item">Deleted Pages</a>
+		<a permission="EditWikiRedirects" asp-page="/Wiki/Redirects/Index" class="dropdown-item">Redirects</a>
 	</nav-dropdown>
 	<nav-dropdown activate="Admin"
 				  permissions="new[] { PermissionTo.ViewPrivateUserData, PermissionTo.EditUsers, PermissionTo.EditRoles, PermissionTo.TagMaintenance, PermissionTo.GameSystemMaintenance, PermissionTo.CreateAwards }">

--- a/TASVideos/Pages/Wiki/Redirects/Create.cshtml
+++ b/TASVideos/Pages/Wiki/Redirects/Create.cshtml
@@ -1,0 +1,28 @@
+@page
+@model CreateModel
+@{
+	ViewData.SetTitle("Creating a new Wiki Redirect");
+}
+
+<form client-side-validation="true" method="post">
+	<row>
+		<column lg="6">
+			<fieldset>
+				<label asp-for="WikiRedirect.PageNameFrom"></label>
+				<input asp-for="WikiRedirect.PageNameFrom" placeholder="OldPage/Example" />
+				<span asp-validation-for="WikiRedirect.PageNameFrom"></span>
+			</fieldset>
+		</column>
+		<column lg="6">
+			<fieldset>
+				<label asp-for="WikiRedirect.PageNameTo"></label>
+				<input asp-for="WikiRedirect.PageNameTo" placeholder="NewPage/Example" />
+				<span asp-validation-for="WikiRedirect.PageNameTo"></span>
+			</fieldset>
+		</column>
+	</row>
+	<form-button-bar>
+		<submit-button edit="false"></submit-button>
+		<cancel-link asp-page="Index"></cancel-link>
+	</form-button-bar>
+</form>

--- a/TASVideos/Pages/Wiki/Redirects/Create.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Redirects/Create.cshtml.cs
@@ -1,0 +1,68 @@
+namespace TASVideos.Pages.Wiki.Redirects;
+
+[RequirePermission(PermissionTo.EditWikiRedirects)]
+public class CreateModel(ApplicationDbContext db) : BasePageModel
+{
+	[BindProperty]
+	public WikiRedirect WikiRedirect { get; set; } = new();
+
+	public async Task<IActionResult> OnPost()
+	{
+		if (!ModelState.IsValid)
+		{
+			return Page();
+		}
+
+		if (WikiRedirect.PageNameFrom == WikiRedirect.PageNameTo)
+		{
+			ModelState.AddModelError("", "Page names must be different");
+		}
+
+		if (!WikiHelper.IsValidWikiPageName(WikiRedirect.PageNameFrom))
+		{
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameFrom)}", "Page name is not valid");
+		}
+
+		if (!WikiHelper.IsValidWikiPageName(WikiRedirect.PageNameTo))
+		{
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameTo)}", "Page name is not valid");
+		}
+
+		if (!ModelState.IsValid)
+		{
+			return Page();
+		}
+
+		if (await db.WikiRedirects.AnyAsync(r => r.PageNameFrom == WikiRedirect.PageNameTo))
+		{
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameTo)}", $"Page name '{WikiRedirect.PageNameTo}' already redirects to a different page. Avoid multiple redirects.");
+			return Page();
+		}
+
+		db.WikiRedirects.Add(WikiRedirect);
+
+		try
+		{
+			await db.SaveChangesAsync();
+		}
+		catch (DbUpdateConcurrencyException)
+		{
+			ErrorStatusMessage("Unable to edit tag due to an unknown error");
+			return Page();
+		}
+		catch (DbUpdateException ex)
+		{
+			if (ex.InnerException?.Message.Contains("unique constraint") ?? false)
+			{
+				ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameFrom)}", $"Redirect from '{WikiRedirect.PageNameFrom}' already exists");
+				return Page();
+			}
+
+			ErrorStatusMessage("Unable to edit tag due to an unknown error");
+			return Page();
+		}
+
+		SuccessStatusMessage("Redirect successfully created.");
+		return BasePageRedirect("Index");
+	}
+}

--- a/TASVideos/Pages/Wiki/Redirects/Edit.cshtml
+++ b/TASVideos/Pages/Wiki/Redirects/Edit.cshtml
@@ -1,0 +1,28 @@
+@page "{id}"
+@model EditModel
+@{
+	ViewData.SetTitle($"Editing Redirect from '{Model.WikiRedirect.PageNameFrom}' to '{Model.WikiRedirect.PageNameTo}'");
+}
+
+<form client-side-validation="true" method="post">
+	<row>
+		<column lg="6">
+			<fieldset>
+				<label asp-for="WikiRedirect.PageNameFrom"></label>
+				<input asp-for="WikiRedirect.PageNameFrom" placeholder="OldPage/Example" />
+				<span asp-validation-for="WikiRedirect.PageNameFrom"></span>
+			</fieldset>
+		</column>
+		<column lg="6">
+			<fieldset>
+				<label asp-for="WikiRedirect.PageNameTo"></label>
+				<input asp-for="WikiRedirect.PageNameTo" placeholder="NewPage/Example" />
+				<span asp-validation-for="WikiRedirect.PageNameTo"></span>
+			</fieldset>
+		</column>
+	</row>
+	<form-button-bar>
+		<submit-button></submit-button>
+		<cancel-link asp-page="Index"></cancel-link>
+	</form-button-bar>
+</form>

--- a/TASVideos/Pages/Wiki/Redirects/Edit.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Redirects/Edit.cshtml.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TASVideos.Pages.Wiki.Redirects;
+
+[RequirePermission(PermissionTo.EditWikiRedirects)]
+public class EditModel(ApplicationDbContext db) : BasePageModel
+{
+	[FromRoute]
+	public int Id { get; set; }
+
+	[BindProperty]
+	public WikiRedirect WikiRedirect { get; set; } = new();
+
+	public async Task<IActionResult> OnGet()
+	{
+		var redirect = await db.WikiRedirects.FindAsync(Id);
+		if (redirect == null)
+		{
+			return NotFound();
+		}
+
+		WikiRedirect = redirect;
+
+		return Page();
+	}
+
+	public async Task<IActionResult> OnPost()
+	{
+		if (!ModelState.IsValid)
+		{
+			return Page();
+		}
+
+		if (WikiRedirect.PageNameFrom == WikiRedirect.PageNameTo)
+		{
+			ModelState.AddModelError("", "Page names must be different");
+		}
+
+		if (!WikiHelper.IsValidWikiPageName(WikiRedirect.PageNameFrom))
+		{
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameFrom)}", "Page name is not valid");
+		}
+
+		if (!WikiHelper.IsValidWikiPageName(WikiRedirect.PageNameTo))
+		{
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameTo)}", "Page name is not valid");
+		}
+
+		if (!ModelState.IsValid)
+		{
+			return Page();
+		}
+
+		if (await db.WikiRedirects.AnyAsync(r => r.Id != Id && r.PageNameFrom == WikiRedirect.PageNameTo))
+		{
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameTo)}", $"Page name '{WikiRedirect.PageNameTo}' already redirects to a different page. Avoid multiple redirects.");
+			return Page();
+		}
+
+		var redirect = await db.WikiRedirects.FindAsync(Id);
+		if (redirect == null)
+		{
+			return NotFound();
+		}
+
+		redirect.PageNameFrom = WikiRedirect.PageNameFrom;
+		redirect.PageNameTo = WikiRedirect.PageNameTo;
+
+		try
+		{
+			await db.SaveChangesAsync();
+		}
+		catch (DbUpdateConcurrencyException)
+		{
+			ErrorStatusMessage("Unable to edit redirect due to an unknown error");
+			return Page();
+		}
+		catch (DbUpdateException ex)
+		{
+			if (ex.InnerException?.Message.Contains("unique constraint") ?? false)
+			{
+				ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameFrom)}", $"Redirect from '{WikiRedirect.PageNameFrom}' already exists");
+				return Page();
+			}
+
+			ErrorStatusMessage("Unable to edit redirect due to an unknown error");
+			return Page();
+		}
+
+		SuccessStatusMessage("Redirect successfully updated.");
+		return BasePageRedirect("Index");
+	}
+}

--- a/TASVideos/Pages/Wiki/Redirects/Index.cshtml
+++ b/TASVideos/Pages/Wiki/Redirects/Index.cshtml
@@ -1,0 +1,23 @@
+@page
+@model IndexModel
+@{
+	ViewData.SetTitle("Wiki Redirects");
+}
+<top-button-bar>
+	<add-link asp-page="Create"></add-link>
+</top-button-bar>
+<standard-table>
+	<table-head columns="From,To,"></table-head>
+	@foreach (var redirect in Model.Redirects)
+	{
+		<tr>
+			<td>@redirect.PageNameFrom</td>
+			<td>@redirect.PageNameTo</td>
+			<td-action-column>
+				<edit-link asp-page="Edit" asp-route-id="@redirect.Id"></edit-link>
+				<delete-button asp-href="/Wiki/Redirects/Index?handler=Delete&id=@redirect.Id"
+							   warning-message="Are you sure you want to remove this redirect?"></delete-button>
+			</td-action-column>
+		</tr>
+	}
+</standard-table>

--- a/TASVideos/Pages/Wiki/Redirects/Index.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Redirects/Index.cshtml.cs
@@ -1,0 +1,29 @@
+namespace TASVideos.Pages.Wiki.Redirects;
+
+[RequirePermission(PermissionTo.EditWikiRedirects)]
+public class IndexModel(ApplicationDbContext db) : BasePageModel
+{
+	public List<WikiRedirect> Redirects { get; set; } = [];
+
+	public async Task OnGet()
+	{
+		Redirects = await db.WikiRedirects
+			.OrderBy(r => r.PageNameFrom)
+			.ThenBy(r => r.PageNameTo)
+			.ToListAsync();
+	}
+
+	public async Task<IActionResult> OnPostDelete(int id)
+	{
+		var redirect = await db.WikiRedirects.FindAsync(id);
+		if (redirect is null)
+		{
+			return NotFound();
+		}
+
+		db.WikiRedirects.Remove(redirect);
+		SetMessage(await db.TrySaveChanges(), $"Redirect from '{redirect.PageNameFrom}' to '{redirect.PageNameTo}' deleted successfully", $"Unable to delete redirect from '{redirect.PageNameFrom}' to '{redirect.PageNameTo}'");
+
+		return BasePageRedirect("Index");
+	}
+}

--- a/TASVideos/Pages/Wiki/Render.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Render.cshtml.cs
@@ -57,6 +57,12 @@ public class RenderModel(IWikiPages wikiPages, ApplicationDbContext db, ILogger<
 			return Redirect("/" + url);
 		}
 
+		var redirect = await db.WikiRedirects.FirstOrDefaultAsync(r => r.PageNameFrom == url);
+		if (redirect != null)
+		{
+			return Redirect("/" + redirect.PageNameTo);
+		}
+
 		return RedirectToPage("/Wiki/PageDoesNotExist", new { url });
 	}
 


### PR DESCRIPTION
Resolves #2298 .

Previous attempt at wiki redirects was in PR #1593 .
This PR implements what I said in the [previous PR's comment](https://github.com/TASVideos/tasvideos/pull/1593#issuecomment-1618451943) except for the automatic redirect creation on moves.

Avoids loops by not allowing multiple redirect hops to be created (i.e. if A -> B exists, do not allow new redirect to A).