### PR TITLE
Fix pc system

### DIFF
--- a/TASVideos.Parsers/Parsers/Dft.cs
+++ b/TASVideos.Parsers/Parsers/Dft.cs
@@ -12,7 +12,7 @@ internal class Dft : Parser, IParser
 		var result = new SuccessResult(FileExtension)
 		{
 			Region = RegionType.Ntsc,
-			SystemCode = SystemCodes.Windows,
+			SystemCode = SystemCodes.Pc,
 			FrameRateOverride = FrameRate,
 		};
 

--- a/TASVideos.Parsers/Parsers/Tas.cs
+++ b/TASVideos.Parsers/Parsers/Tas.cs
@@ -13,7 +13,7 @@ internal class Tas : Parser, IParser
 		var result = new SuccessResult(FileExtension)
 		{
 			Region = RegionType.Ntsc,
-			SystemCode = SystemCodes.Celeste,
+			SystemCode = SystemCodes.Pc,
 			FrameRateOverride = 1000.0 / 17.0
 		};
 

--- a/TASVideos.Parsers/SystemCodes.cs
+++ b/TASVideos.Parsers/SystemCodes.cs
@@ -10,7 +10,6 @@ internal static class SystemCodes
 	public const string Bsx = "bsx";
 	public const string C64 = "c64";
 	public const string Cdi = "cdi";
-	public const string Celeste = "celeste";
 	public const string Coleco = "coleco";
 	public const string Dos = "dos";
 	public const string Ds = "ds";

--- a/tests/TASVideos.MovieParsers.Tests/DftTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/DftTests.cs
@@ -68,7 +68,7 @@ public class DftTests : BaseParserTests
 		var result = await _dftParser.Parse(Embedded("2frames.dft", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(SystemCodes.Windows, result.SystemCode);
+		Assert.AreEqual(SystemCodes.Pc, result.SystemCode);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/TasTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/TasTests.cs
@@ -33,7 +33,7 @@ public class TasTests : BaseParserTests
 		var result = await _tasParser.Parse(Embedded("2465ms.tas", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(SystemCodes.Celeste, result.SystemCode);
+		Assert.AreEqual(SystemCodes.Pc, result.SystemCode);
 	}
 
 	[TestMethod]


### PR DESCRIPTION
Follow-up to PR #2304 because the new parser merged in PR #2300 still used the old Windows system.
Additionally we change Celeste system to PC as well, as per consensus.