### PR TITLE
Add API endpoints to regenerate Publication and Submission titles

### DIFF
--- a/TASVideos.Api/Endpoints/PublicationsEndpoints.cs
+++ b/TASVideos.Api/Endpoints/PublicationsEndpoints.cs
@@ -1,3 +1,6 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using System.Linq.Expressions;
+
 namespace TASVideos.Api.Endpoints;
 
 internal static class PublicationsEndpoints
@@ -32,6 +35,33 @@ internal static class PublicationsEndpoints
 		})
 		.Receives<PublicationsRequest>()
 		.ProducesList<PublicationsResponse>("a list of publications, searchable by the given criteria");
+
+		group.MapPost("{id:int}/regenerate-title", async (int id, ApplicationDbContext db, HttpContext context) =>
+		{
+			var authError = ApiResults.Authorize(PermissionTo.EditPublicationMetaData, context);
+			if (authError is not null)
+			{
+				return authError;
+			}
+
+			var publication = await db.Publications
+				.IncludeTitleTables()
+				.FirstOrDefaultAsync(p => p.Id == id);
+
+			if (publication is null)
+			{
+				return Results.NotFound();
+			}
+
+			publication.Title = publication.GenerateTitle();
+
+			await db.SaveChangesAsync();
+
+			return Results.Ok();
+		})
+		.WithSummary("Regenerates the title of the publication with the given id. This does not affect any YouTube titles.")
+		.Produces(StatusCodes.Status200OK)
+		.Produces(StatusCodes.Status404NotFound);
 
 		return app;
 	}

--- a/TASVideos.Api/Endpoints/PublicationsEndpoints.cs
+++ b/TASVideos.Api/Endpoints/PublicationsEndpoints.cs
@@ -1,6 +1,3 @@
-using Microsoft.AspNetCore.Http.HttpResults;
-using System.Linq.Expressions;
-
 namespace TASVideos.Api.Endpoints;
 
 internal static class PublicationsEndpoints

--- a/TASVideos.Api/Endpoints/SubmissionsEndpoints.cs
+++ b/TASVideos.Api/Endpoints/SubmissionsEndpoints.cs
@@ -33,6 +33,36 @@ internal static class SubmissionsEndpoints
 		.Receives<SubmissionsRequest>()
 		.ProducesList<SubmissionsResponse>("a list of submissions, searchable by the given criteria.");
 
+		group.MapPost("{id:int}/regenerate-title", async (int id, ApplicationDbContext db, HttpContext context) =>
+		{
+			var authError = ApiResults.Authorize(PermissionTo.EditSubmissions, context);
+			if (authError is not null)
+			{
+				return authError;
+			}
+
+			var submission = await db.Submissions
+				.IncludeTitleTables()
+				.FirstOrDefaultAsync(p => p.Id == id);
+
+			if (submission is null)
+			{
+				return Results.NotFound();
+			}
+
+			submission.GenerateTitle();
+
+			var topic = await db.ForumTopics.FindAsync(submission.TopicId);
+			topic?.Title = submission.Title;
+
+			await db.SaveChangesAsync();
+
+			return Results.Ok();
+		})
+		.WithSummary("Regenerates the title of the submission with the given id.")
+		.Produces(StatusCodes.Status200OK)
+		.Produces(StatusCodes.Status404NotFound);
+
 		return app;
 	}
 }


### PR DESCRIPTION
For submissions, this also update the topic title.
For publications, this does *not* update the youtube video(s), as that uses up YouTube API quota. That might need more careful consideration at a later date.