### PR TITLE
Make navbar submenus (non-hyperlink items) into `<button/>`s

### DIFF
--- a/TASVideos/TagHelpers/NavbarTagHelpers.cs
+++ b/TASVideos/TagHelpers/NavbarTagHelpers.cs
@@ -51,7 +51,7 @@ public class NavDropdownTagHelper : NavItemBase
 		}
 
 		output.Content.SetHtmlContent(
-			$"<a href='#' class='{addClass}' data-bs-toggle='dropdown'>{Name ?? ""}<span class='caret'></span></a>");
+			$"<a href='#' class='{addClass}' data-bs-toggle='dropdown'>{Name ?? ""}</a>");
 
 		output.Content.AppendHtml($"<div class='dropdown-menu'>{content}</div>");
 	}

--- a/TASVideos/TagHelpers/NavbarTagHelpers.cs
+++ b/TASVideos/TagHelpers/NavbarTagHelpers.cs
@@ -51,7 +51,7 @@ public class NavDropdownTagHelper : NavItemBase
 		}
 
 		output.Content.SetHtmlContent(
-			$"<a href='#' class='{addClass}' data-bs-toggle='dropdown'>{Name ?? ""}</a>");
+			$"<button type='button' class='{addClass}' data-bs-toggle='dropdown'>{Name ?? ""}</button>");
 
 		output.Content.AppendHtml($"<div class='dropdown-menu'>{content}</div>");
 	}

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -163,6 +163,11 @@ h4 {
 	color: RGBA(255,255,255,.6);
 }
 
+/** to complement the underline on `a.nav-link` (all hyperlinks actually) */
+button.nav-link:hover {
+	text-decoration: underline;
+}
+
 .breadcrumb-item {
 	font-size: 1.25em;
 	line-height: 1.25em;


### PR DESCRIPTION
From #2287:
> Them being `<a/>`s in the first place *is* the a11y concern, because [links](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#onclick_events) [aren't](https://webaim.org/techniques/hypertext/#keyboard) [buttons](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role#accessibility_concerns). Starting with that as a first principle, you can then style them to look similar, which Bootstrap does.