### PR TITLE
Make game list sorting determinstic

### DIFF
--- a/TASVideos.Core/Paging/Paginator.cs
+++ b/TASVideos.Core/Paging/Paginator.cs
@@ -84,25 +84,20 @@ public static class Paginator
 	/// <typeparam name="T">The type of the elements of source.</typeparam>
 	public static IQueryable<T> SortBy<T>(this IQueryable<T> source, ISortable? request)
 	{
-		if (string.IsNullOrWhiteSpace(request?.Sort))
-		{
-			// per below, can't noop
-			return ApplyDefaultSort(source);
-		}
-
-		var columns = request.Sort.SplitWithEmpty(",").Select(s => s.Trim());
-		var anySortApplied = false;
 		var thenBy = false;
-		foreach (var column in columns)
+
+		if (!string.IsNullOrWhiteSpace(request?.Sort))
 		{
-			source = SortByParam(source, column, thenBy, out var sortApplied);
-			anySortApplied |= sortApplied;
-			thenBy = true;
+			var columns = request.Sort.SplitWithEmpty(",").Select(s => s.Trim());
+			foreach (var column in columns)
+			{
+				source = SortByParam(source, column, thenBy, out var sortApplied);
+				thenBy |= sortApplied;
+			}
 		}
 
-		// if we haven't added an `OrderBy` to the chain yet, we need to do that now or bad things happen
-		// the caller is expecting us to, and if they go on to call `Take`/`Skip`, it hits UB
-		return anySortApplied ? source : ApplyDefaultSort(source);
+		// we always add a default sort for deterministic paging
+		return ApplyDefaultSort(source, thenBy);
 	}
 
 	private static IQueryable<T> SortByParam<T>(IQueryable<T> query, string? column, bool thenBy, out bool sortApplied)
@@ -157,17 +152,16 @@ public static class Paginator
 		return (IQueryable<T>)result;
 	}
 
-	private static IQueryable<T> ApplyDefaultSort<T>(IQueryable<T> query)
+	private static IQueryable<T> ApplyDefaultSort<T>(IQueryable<T> query, bool thenBy)
 	{
 		var allProps = typeof(T).GetProperties();
 		var idProp = allProps.SingleOrDefault(x => string.Equals(x.Name, "id", StringComparison.OrdinalIgnoreCase));
-		if (idProp?.GetCustomAttribute<SortableAttribute>() is not null)
+		if (idProp is not null)
 		{
-			return SortByParamInner(query, idProp.Name, desc: false, thenBy: false);
+			return SortByParamInner(query, idProp.Name, desc: false, thenBy: thenBy);
 		}
 
-		// worst case, just do everything
-		var thenBy = false;
+		// worst case, just sort by all sortables
 		foreach (var pi in allProps.Where(pi => pi.GetCustomAttribute<SortableAttribute>() is not null))
 		{
 			query = SortByParamInner(query, pi.Name.ToLowerInvariant(), desc: false, thenBy: thenBy);

--- a/TASVideos/Pages/Games/List.cshtml.cs
+++ b/TASVideos/Pages/Games/List.cshtml.cs
@@ -101,7 +101,7 @@ public class ListModel(ApplicationDbContext db) : BasePageModel
 		.SortedPageOf(paging);
 	}
 
-	[PagingDefaults(PageSize = 50, Sort = "-Publications,Name,Id")]
+	[PagingDefaults(PageSize = 50, Sort = "-Publications")]
 	public class GameListRequest : PagingModel
 	{
 		public string? System { get; set; }

--- a/TASVideos/Pages/Games/List.cshtml.cs
+++ b/TASVideos/Pages/Games/List.cshtml.cs
@@ -101,7 +101,7 @@ public class ListModel(ApplicationDbContext db) : BasePageModel
 		.SortedPageOf(paging);
 	}
 
-	[PagingDefaults(PageSize = 50, Sort = "-Publications")]
+	[PagingDefaults(PageSize = 50, Sort = "-Publications,Name,Id")]
 	public class GameListRequest : PagingModel
 	{
 		public string? System { get; set; }

--- a/tests/TASVideos.Core.Tests/Paging/PaginatorTests.cs
+++ b/tests/TASVideos.Core.Tests/Paging/PaginatorTests.cs
@@ -1,0 +1,54 @@
+using TASVideos.Data.Entity.Game;
+
+namespace TASVideos.Core.Tests.Paging;
+
+[TestClass]
+public class PaginatorTests : TestDbBase
+{
+	[TestMethod]
+	public async Task SortedPageOf_DeterministicOrdering()
+	{
+		const int AddCount = 30;
+		const int MaxSuffix = 4; // forces duplicates
+
+		for (int i = 0; i < AddCount; i++)
+		{
+			_db.Games.Add(new Game
+			{
+				DisplayName = $"Game {Random.Shared.Next(MaxSuffix)}"
+			});
+		}
+
+		await _db.SaveChangesAsync();
+
+		HashSet<int> pageResults = [];
+
+		for (int i = 0; i < AddCount; i++)
+		{
+			var page = await _db.Games
+				.Select(g => new GameEntry
+				{
+					Id = g.Id,
+					DisplayName = g.DisplayName
+				})
+				.SortedPageOf(new PagingModel
+				{
+					Sort = nameof(GameEntry.DisplayName),
+					PageSize = 1,
+					CurrentPage = i + 1
+				});
+
+			pageResults.Add(page.First().Id);
+		}
+
+		// if the ordering is deterministic, each id should appear exactly once, so the count should be equal to the number of entries added
+		Assert.HasCount(AddCount, pageResults);
+	}
+
+	private class GameEntry
+	{
+		public int Id { get; set; }
+		[Sortable]
+		public string DisplayName { get; set; } = "";
+	}
+}


### PR DESCRIPTION
Fixing the bug where some games did not appear due to having the same publication count on a page border.

Edit: Actually this is a bigger bug that can't be solved by just adding more sorting. After all, once a user manually performs a sort, it will only be on a single column, causing non-determinstic sortings again... I'll look into fixing this more generally.

Edit2: Fixed it by adding our default sort always, even if a previous sort is given.