### PR TITLE
Better .zip handling

### DIFF
--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -69,7 +69,6 @@ public interface IQueueService
 
 	/// <summary>
 	/// Parses an individual movie file and returns the parse result along with the movie file bytes
-	/// Does not support zip files - only individual movie files
 	/// </summary>
 	Task<(IParseResult ParseResult, byte[] MovieFileBytes)> ParseMovieFile(IFormFile movieFile);
 

--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -68,12 +68,6 @@ public interface IQueueService
 	Task<ObsoletePublicationResult?> GetObsoletePublicationTags(int publicationId);
 
 	/// <summary>
-	/// Parses a movie file and returns the parse result along with the movie file bytes
-	/// Supports both zip files and individual movie files
-	/// </summary>
-	Task<(IParseResult ParseResult, byte[] MovieFileBytes)> ParseMovieFileOrZip(IFormFile movieFile);
-
-	/// <summary>
 	/// Parses an individual movie file and returns the parse result along with the movie file bytes
 	/// Does not support zip files - only individual movie files
 	/// </summary>
@@ -339,7 +333,7 @@ internal class QueueService(
 
 		if (request.ReplaceMovieFile is not null)
 		{
-			var (parseResult, movieFileBytes) = await ParseMovieFileOrZip(request.ReplaceMovieFile);
+			var (parseResult, movieFileBytes) = await ParseMovieFile(request.ReplaceMovieFile);
 			if (!parseResult.Success)
 			{
 				return UpdateSubmissionResult.Error("Movie file parsing failed");
@@ -503,7 +497,7 @@ internal class QueueService(
 			submission.Title);
 	}
 
-	public async Task<(IParseResult ParseResult, byte[] MovieFileBytes)> ParseMovieFileOrZip(IFormFile movieFile)
+	public async Task<(IParseResult ParseResult, byte[] MovieFileBytes)> ParseMovieFile(IFormFile movieFile)
 	{
 		// Inline implementation of DecompressOrTakeRaw
 		var rawFileStream = new MemoryStream();
@@ -526,46 +520,7 @@ internal class QueueService(
 			fileStream = rawFileStream;
 		}
 
-		var fileBytes = fileStream.ToArray();
-
-		// Inline implementation of IsZip
-		var isZip = movieFile.FileName.EndsWith(".zip")
-			&& movieFile.ContentType is "application/x-zip-compressed" or "application/zip";
-
-		var parseResult = isZip
-			? await movieParser.ParseZip(fileStream)
-			: await movieParser.ParseFile(movieFile.FileName, fileStream);
-
-		var movieFileBytes = isZip
-			? fileBytes
-			: await fileService.ZipFile(fileBytes, movieFile.FileName);
-
-		return (parseResult, movieFileBytes);
-	}
-
-	public async Task<(IParseResult ParseResult, byte[] MovieFileBytes)> ParseMovieFile(IFormFile movieFile)
-	{
-		var rawFileStream = new MemoryStream();
-		await movieFile.CopyToAsync(rawFileStream);
-
-		MemoryStream fileStream;
-		try
-		{
-			rawFileStream.Position = 0;
-			using var gzip = new GZipStream(rawFileStream, CompressionMode.Decompress, leaveOpen: true);
-			var decompressedFileStream = new MemoryStream();
-			await gzip.CopyToAsync(decompressedFileStream);
-			await rawFileStream.DisposeAsync();
-			decompressedFileStream.Position = 0;
-			fileStream = decompressedFileStream;
-		}
-		catch (InvalidDataException)
-		{
-			rawFileStream.Position = 0;
-			fileStream = rawFileStream;
-		}
-
-		// Parse the individual movie file (not a zip)
+		// Parse the individual movie file
 		var parseResult = await movieParser.ParseFile(movieFile.FileName, fileStream);
 
 		// Get the file bytes for storage

--- a/TASVideos.Parsers/Extensions/Extensions.cs
+++ b/TASVideos.Parsers/Extensions/Extensions.cs
@@ -135,13 +135,22 @@ internal static class Extensions
 
 	extension(Stream stream)
 	{
-		public async Task<SharpZipArchive> OpenZipArchiveRead()
+		public async Task<SharpZipArchive?> OpenZipArchiveRead()
 		{
 			// A seekable stream is required for SharpZipArchive.Open
 			// Doing a copy here should be fairly cheap, and is fine for reading
 			// (This is normally done implicitly in BCL's ZipArchive ctor in Read mode)
 			var ms = new MemoryStream();
 			await stream.CopyToAsync(ms);
+			ms.Seek(0, SeekOrigin.Begin);
+
+			// Make sure this is actually a zip file
+			if (!SharpZipArchive.IsZipFile(ms))
+			{
+				return null;
+			}
+
+			ms.Seek(0, SeekOrigin.Begin);
 			return SharpZipArchive.Open(ms);
 		}
 

--- a/TASVideos.Parsers/IMovieParser.cs
+++ b/TASVideos.Parsers/IMovieParser.cs
@@ -5,8 +5,7 @@ namespace TASVideos.MovieParsers;
 
 /// <summary>
 /// The entry point for movie file parsers
-/// Takes a stream of the zip file containing a movie file
-/// The file must have precisely one file
+/// Takes a stream of the movie file
 /// The file is processed and an <see cref="IParseResult"/>
 /// is returned.
 /// </summary>

--- a/TASVideos.Parsers/IMovieParser.cs
+++ b/TASVideos.Parsers/IMovieParser.cs
@@ -37,9 +37,17 @@ internal sealed class MovieParser : IMovieParser
 		try
 		{
 			using var zip = await stream.OpenZipArchiveRead();
-			if (zip.Entries.Count > 1)
+			if (zip == null)
 			{
-				return Error("Multiple files detected in the .zip, only one file is allowed");
+				return Error("Invalid file format, does not seem to be a .zip");
+			}
+
+			switch (zip.Entries.Count)
+			{
+				case 0:
+					return Error("No files are present in the .zip");
+				case > 1:
+					return Error("Multiple files detected in the .zip, only one file is allowed");
 			}
 
 			var movieFile = zip.Entries.First();

--- a/TASVideos.Parsers/IMovieParser.cs
+++ b/TASVideos.Parsers/IMovieParser.cs
@@ -14,7 +14,6 @@ namespace TASVideos.MovieParsers;
 public interface IMovieParser
 {
 	IEnumerable<string> SupportedMovieExtensions { get; }
-	Task<IParseResult> ParseZip(Stream stream);
 	Task<IParseResult> ParseFile(string fileName, Stream stream);
 }
 
@@ -31,43 +30,6 @@ internal sealed class MovieParser : IMovieParser
 	public IEnumerable<string> SupportedMovieExtensions => ParserTypes
 		.Select(t => "." + (t.GetCustomAttribute(typeof(FileExtensionAttribute)) as FileExtensionAttribute)
 				?.Extension);
-
-	public async Task<IParseResult> ParseZip(Stream stream)
-	{
-		try
-		{
-			using var zip = await stream.OpenZipArchiveRead();
-			if (zip == null)
-			{
-				return Error("Invalid file format, does not seem to be a .zip");
-			}
-
-			switch (zip.Entries.Count)
-			{
-				case 0:
-					return Error("No files are present in the .zip");
-				case > 1:
-					return Error("Multiple files detected in the .zip, only one file is allowed");
-			}
-
-			var movieFile = zip.Entries.First();
-			var ext = Path.GetExtension(movieFile.Key ?? "").Trim('.').ToLower();
-
-			var parser = GetParser(ext);
-			if (parser is null)
-			{
-				return Error($".{ext} files are not currently supported.");
-			}
-
-			await using var movieFileStream = movieFile.OpenEntryStream();
-			return await parser.Parse(movieFileStream, movieFile.Size);
-		}
-		catch (Exception)
-		{
-			// TODO: do we want to log here? or catch at a higher layer?
-			return Error("A general error occured while processing the movie file.");
-		}
-	}
 
 	public async Task<IParseResult> ParseFile(string fileName, Stream stream)
 	{

--- a/TASVideos.Parsers/Parsers/Bk2.cs
+++ b/TASVideos.Parsers/Parsers/Bk2.cs
@@ -37,6 +37,10 @@ internal class Bk2 : Parser, IParser
 		};
 
 		var archive = await file.OpenZipArchiveRead();
+		if (archive == null)
+		{
+			return InvalidFormat();
+		}
 
 		foreach (var entry in InvalidArchiveEntries)
 		{

--- a/TASVideos.Parsers/Parsers/Lsmv.cs
+++ b/TASVideos.Parsers/Parsers/Lsmv.cs
@@ -18,6 +18,10 @@ internal class Lsmv : Parser, IParser
 		};
 
 		var archive = await file.OpenZipArchiveRead();
+		if (archive == null)
+		{
+			return InvalidFormat();
+		}
 
 		// a .lsmv is actually a savestate if a savestate file is present
 		if (archive.Entries.Any(e => e.Key is not null && e.Key.Equals(Savestate, StringComparison.InvariantCultureIgnoreCase)))

--- a/TASVideos/Pages/Submissions/Submit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Submit.cshtml.cs
@@ -102,7 +102,7 @@ public class SubmitModel(
 			return Page();
 		}
 
-		var (parseResult, movieFileBytes) = await queueService.ParseMovieFileOrZip(MovieFile!);
+		var (parseResult, movieFileBytes) = await queueService.ParseMovieFile(MovieFile!);
 		if (!parseResult.Success)
 		{
 			ModelState.AddParseErrors(parseResult);

--- a/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
@@ -1364,7 +1364,7 @@ public class QueueServiceTests : TestDbBase
 	#region ParseMovieFile
 
 	[TestMethod]
-	public async Task ParseMovieFile_ParsesZipAndReturnsRawBytes()
+	public async Task ParseMovieFile_ParsesFileAndReturnsRawBytes()
 	{
 		var formFile = Substitute.For<IFormFile>();
 		formFile.FileName.Returns("test.bk2");

--- a/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
@@ -1364,7 +1364,7 @@ public class QueueServiceTests : TestDbBase
 	#region ParseMovieFile
 
 	[TestMethod]
-	public async Task ParseMovieFile_ParsesFileAndZipsResult()
+	public async Task ParseMovieFile_ParsesZipAndReturnsRawBytes()
 	{
 		var formFile = Substitute.For<IFormFile>();
 		formFile.FileName.Returns("test.bk2");
@@ -1380,15 +1380,12 @@ public class QueueServiceTests : TestDbBase
 
 		_movieParser.ParseFile("test.bk2", Arg.Any<Stream>()).Returns(parseResult);
 
-		var zippedBytes = new byte[] { 5, 6, 7, 8, 9 };
-		_fileService.ZipFile(Arg.Any<byte[]>(), "test.bk2").Returns(zippedBytes);
-
 		var (result, movieBytes) = await _queueService.ParseMovieFile(formFile);
 
 		Assert.AreEqual(parseResult, result);
-		Assert.AreEqual(zippedBytes, movieBytes);
+		Assert.HasCount(4, movieBytes); // Raw file bytes
 		await _movieParser.Received(1).ParseFile("test.bk2", Arg.Any<Stream>());
-		await _fileService.Received(1).ZipFile(Arg.Any<byte[]>(), "test.bk2");
+		await _fileService.DidNotReceive().ZipFile(Arg.Any<byte[]>(), Arg.Any<string>());
 	}
 
 	#endregion

--- a/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
@@ -1364,7 +1364,7 @@ public class QueueServiceTests : TestDbBase
 	#region ParseMovieFile
 
 	[TestMethod]
-	public async Task ParseMovieFile_NonZipFile_ParsesFileAndZipsResult()
+	public async Task ParseMovieFile_ParsesFileAndZipsResult()
 	{
 		var formFile = Substitute.For<IFormFile>();
 		formFile.FileName.Returns("test.bk2");
@@ -1383,36 +1383,12 @@ public class QueueServiceTests : TestDbBase
 		var zippedBytes = new byte[] { 5, 6, 7, 8, 9 };
 		_fileService.ZipFile(Arg.Any<byte[]>(), "test.bk2").Returns(zippedBytes);
 
-		var (result, movieBytes) = await _queueService.ParseMovieFileOrZip(formFile);
+		var (result, movieBytes) = await _queueService.ParseMovieFile(formFile);
 
 		Assert.AreEqual(parseResult, result);
 		Assert.AreEqual(zippedBytes, movieBytes);
 		await _movieParser.Received(1).ParseFile("test.bk2", Arg.Any<Stream>());
 		await _fileService.Received(1).ZipFile(Arg.Any<byte[]>(), "test.bk2");
-	}
-
-	[TestMethod]
-	public async Task ParseMovieFile_ZipFile_ParsesZipAndReturnsRawBytes()
-	{
-		var formFile = Substitute.For<IFormFile>();
-		formFile.FileName.Returns("test.zip");
-		formFile.ContentType.Returns("application/zip");
-
-		var fileStream = new MemoryStream([1, 2, 3, 4]);
-		formFile.CopyToAsync(Arg.Any<Stream>()).Returns(Task.CompletedTask)
-			.AndDoes(x => fileStream.CopyTo((Stream)x.Args()[0]));
-
-		var parseResult = Substitute.For<IParseResult>();
-		parseResult.Success.Returns(true);
-
-		_movieParser.ParseZip(Arg.Any<Stream>()).Returns(parseResult);
-
-		var (result, movieBytes) = await _queueService.ParseMovieFileOrZip(formFile);
-
-		Assert.AreEqual(parseResult, result);
-		Assert.HasCount(4, movieBytes); // Raw file bytes
-		await _movieParser.Received(1).ParseZip(Arg.Any<Stream>());
-		await _fileService.DidNotReceive().ZipFile(Arg.Any<byte[]>(), Arg.Any<string>());
 	}
 
 	#endregion

--- a/tests/TASVideos.E2E.Tests/Base/BaseE2ETest.cs
+++ b/tests/TASVideos.E2E.Tests/Base/BaseE2ETest.cs
@@ -202,7 +202,7 @@ public class BaseE2ETest : PageTest
 			var movieParser = new MovieParser();
 			await using var archive = await ZipFile.OpenReadAsync(downloadPath);
 			var movieFile = archive.Entries.Single();
-			var zipStream = await movieFile.OpenAsync();
+			await using var zipStream = await movieFile.OpenAsync();
 			return await movieParser.ParseFile(movieFile.Name, zipStream);
 		}
 		catch (Exception ex)

--- a/tests/TASVideos.E2E.Tests/Base/BaseE2ETest.cs
+++ b/tests/TASVideos.E2E.Tests/Base/BaseE2ETest.cs
@@ -200,8 +200,10 @@ public class BaseE2ETest : PageTest
 		try
 		{
 			var movieParser = new MovieParser();
-			await using var fileStream = File.OpenRead(downloadPath);
-			return await movieParser.ParseZip(fileStream);
+			await using var archive = await ZipFile.OpenReadAsync(downloadPath);
+			var movieFile = archive.Entries.Single();
+			var zipStream = await movieFile.OpenAsync();
+			return await movieParser.ParseFile(movieFile.Name, zipStream);
 		}
 		catch (Exception ex)
 		{

--- a/tests/TASVideos.RazorPages.Tests/Pages/Submissions/SubmitModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Submissions/SubmitModelTests.cs
@@ -173,7 +173,7 @@ public class SubmitModelTests : TestDbBase
 		parseResult.Success.Returns(true);
 		parseResult.FileExtension.Returns("bk2");
 
-		_queueService.ParseMovieFileOrZip(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
+		_queueService.ParseMovieFile(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
 		_userManager.GetRequiredUser(Arg.Any<ClaimsPrincipal>()).Returns(user);
 		_userManager.Exists("TestUser").Returns(true);
 		_movieFormatDeprecator.IsDeprecated(".bk2").Returns(false);
@@ -220,7 +220,7 @@ public class SubmitModelTests : TestDbBase
 		parseResult.Success.Returns(true);
 		parseResult.FileExtension.Returns("bk2");
 
-		_queueService.ParseMovieFileOrZip(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
+		_queueService.ParseMovieFile(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
 		_userManager.GetRequiredUser(Arg.Any<ClaimsPrincipal>()).Returns(user);
 		_userManager.Exists("TestUser").Returns(true); // Add this line to make validation pass
 		_movieFormatDeprecator.IsDeprecated(".bk2").Returns(false);


### PR DESCRIPTION
Adds checks before opening up a .zip to see if the file is actually a .zip (and return null otherwise). This more just makes it so parsers give a better error than whatever is the first parser error they'd get upon dealing with a ZipArchive that has no entries.

Also removes the .zip movie parsing, not needed anymore and is effectively dead code now. Less code is better code.