### PR TITLE
Add framerate override for .lmp movies

### DIFF
--- a/TASVideos.Parsers/Parsers/Lmp.cs
+++ b/TASVideos.Parsers/Parsers/Lmp.cs
@@ -9,6 +9,8 @@ internal class Lmp : Parser, IParser
 	private const int Maxplayers = 4;
 	private const int Terminator = 0x80;
 	private const int Invalid = -1;
+	private const double NtscDoomFramerate = 35.0029869215506;
+
 	private int FooterPointer { get; set; } = Invalid;
 
 	// order is important here to minimize false detections
@@ -290,7 +292,8 @@ internal class Lmp : Parser, IParser
 		var result = new SuccessResult(FileExtension)
 		{
 			Region = RegionType.Ntsc,
-			SystemCode = SystemCodes.Pc
+			SystemCode = SystemCodes.Pc,
+			FrameRateOverride = NtscDoomFramerate
 		};
 
 		/* A lmp consists of a header, inputs, and a terminator byte


### PR DESCRIPTION
Fixes #2317 

I replicated what's done for other movie formats. Parser tests passed but couldn't figure out how to actually run the site locally for a practical test.

Framerate value was copied from the DOOM system framerate on the site.