### PR TITLE
Add additional check against chaining redirects

### DIFF
--- a/TASVideos/Pages/Wiki/Redirects/Create.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Redirects/Create.cshtml.cs
@@ -35,7 +35,13 @@ public class CreateModel(ApplicationDbContext db) : BasePageModel
 
 		if (await db.WikiRedirects.AnyAsync(r => r.PageNameFrom == WikiRedirect.PageNameTo))
 		{
-			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameTo)}", $"Page name '{WikiRedirect.PageNameTo}' already redirects to a different page. Avoid multiple redirects.");
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameTo)}", $"Page name '{WikiRedirect.PageNameTo}' already redirects to a different page. Avoid chaining redirects.");
+			return Page();
+		}
+
+		if (await db.WikiRedirects.AnyAsync(r => r.PageNameTo == WikiRedirect.PageNameFrom))
+		{
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameFrom)}", $"Another page already redirects to '{WikiRedirect.PageNameFrom}'. Avoid chaining redirects.");
 			return Page();
 		}
 

--- a/TASVideos/Pages/Wiki/Redirects/Edit.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Redirects/Edit.cshtml.cs
@@ -53,7 +53,13 @@ public class EditModel(ApplicationDbContext db) : BasePageModel
 
 		if (await db.WikiRedirects.AnyAsync(r => r.Id != Id && r.PageNameFrom == WikiRedirect.PageNameTo))
 		{
-			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameTo)}", $"Page name '{WikiRedirect.PageNameTo}' already redirects to a different page. Avoid multiple redirects.");
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameTo)}", $"Page name '{WikiRedirect.PageNameTo}' already redirects to a different page. Avoid chaining redirects.");
+			return Page();
+		}
+
+		if (await db.WikiRedirects.AnyAsync(r => r.Id != Id && r.PageNameTo == WikiRedirect.PageNameFrom))
+		{
+			ModelState.AddModelError($"{nameof(WikiRedirect)}.{nameof(WikiRedirect.PageNameFrom)}", $"Another page already redirects to '{WikiRedirect.PageNameFrom}'. Avoid chaining redirects.");
 			return Page();
 		}
 


### PR DESCRIPTION
Fixed a minor oversight when creating redirects.

If you already have a `B -> C` redirect:
* the form would prevent you from creating an `A -> B` redirect
* but it _wouldn't_ prevent you from creating a `C -> D` redirect

This PR adds a check to prevent the latter scenario.