### PR TITLE
Add option to create a redirect when moving a page

### DIFF
--- a/TASVideos/Pages/Wiki/Move.cshtml
+++ b/TASVideos/Pages/Wiki/Move.cshtml
@@ -17,6 +17,10 @@
 				<input asp-for="DestinationPageName" />
 				<span asp-validation-for="DestinationPageName"></span>
 			</fieldset>
+			<fieldset>
+				<input class="form-check-input" type="checkbox" asp-for="LeaveRedirect">
+				<label class="form-check-label" asp-for="LeaveRedirect">Leave a redirect behind</label>
+			</fieldset>
 			<form-button-bar>
 				<submit-button><i class="fa fa-save"></i> Move</submit-button>
 				<cancel-link href="/@Model.OriginalPageName"></cancel-link>

--- a/TASVideos/Pages/Wiki/Move.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Move.cshtml.cs
@@ -3,7 +3,7 @@ using TASVideos.Core.Services.Wiki;
 namespace TASVideos.Pages.Wiki;
 
 [RequirePermission(PermissionTo.MoveWikiPages)]
-public class MoveModel(IWikiPages wikiPages, IExternalMediaPublisher publisher) : BasePageModel
+public class MoveModel(IWikiPages wikiPages, IExternalMediaPublisher publisher, ApplicationDbContext db) : BasePageModel
 {
 	[FromQuery]
 	public string? Path { get; set; }
@@ -14,6 +14,9 @@ public class MoveModel(IWikiPages wikiPages, IExternalMediaPublisher publisher) 
 	[BindProperty]
 	[ValidWikiPageName]
 	public string DestinationPageName { get; set; } = "";
+
+	[BindProperty]
+	public bool LeaveRedirect { get; init; } = true;
 
 	public async Task<IActionResult> OnGet()
 	{
@@ -44,11 +47,51 @@ public class MoveModel(IWikiPages wikiPages, IExternalMediaPublisher publisher) 
 		if (!await wikiPages.CanMove(OriginalPageName, DestinationPageName))
 		{
 			ModelState.AddModelError("", "Either the original page does not exist, or the destination page already exists or has an invalid format.");
+			return Page();
 		}
 
-		if (!ModelState.IsValid)
+		if (LeaveRedirect)
 		{
-			return Page();
+			if (await db.WikiRedirects.AnyAsync(r => r.PageNameTo == OriginalPageName))
+			{
+				ModelState.AddModelError("", $"Another page already redirects to '{OriginalPageName}'. Avoid chaining redirects.");
+				return Page();
+			}
+
+			if (await db.WikiRedirects.AnyAsync(r => r.PageNameFrom == DestinationPageName))
+			{
+				ModelState.AddModelError("", $"Page name '{DestinationPageName}' already redirects to a different page. Avoid chaining redirects.");
+				return Page();
+			}
+
+			WikiRedirect wikiRedirect = new();
+			wikiRedirect.PageNameTo = DestinationPageName;
+			wikiRedirect.PageNameFrom = OriginalPageName;
+
+			db.WikiRedirects.Add(wikiRedirect);
+
+			try
+			{
+				await db.SaveChangesAsync();
+			}
+			catch (DbUpdateConcurrencyException)
+			{
+				ErrorStatusMessage("Unable to edit redirects due to an unknown error");
+				return Page();
+			}
+			catch (DbUpdateException ex)
+			{
+				if (ex.InnerException?.Message.Contains("unique constraint") ?? false)
+				{
+					ModelState.AddModelError("", $"Redirect from '{OriginalPageName}' already exists. Avoid overlapping redirects.");
+					return Page();
+				}
+
+				ErrorStatusMessage("Unable to edit redirects due to an unknown error");
+				return Page();
+			}
+
+			SuccessStatusMessage("Redirect successfully created.");
 		}
 
 		var result = await wikiPages.Move(OriginalPageName, DestinationPageName, User.GetUserId());

--- a/tests/TASVideos.RazorPages.Tests/Pages/Wiki/MoveModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Wiki/MoveModelTests.cs
@@ -15,7 +15,7 @@ public class MoveModelTests : TestDbBase
 	{
 		_wikiPages = Substitute.For<IWikiPages>();
 		var publisher = Substitute.For<IExternalMediaPublisher>();
-		_model = new MoveModel(_wikiPages, publisher);
+		_model = new MoveModel(_wikiPages, publisher, _db);
 	}
 
 	#region OnGet Tests


### PR DESCRIPTION
Resolves #268

Modifying all existing links to a page when it's moved feels unnecessarily expensive and complicated (especially if we include forum posts). Instead, this PR provides an option to automatically create a redirect whenever a page is moved. This is similar to how page moves work on MediaWiki.

I'm guessing editors will want a redirect more often than not, so _the option is true by default._