### PR TITLE
Change topicfeed module to default to topic's title

### DIFF
--- a/TASVideos/WikiModules/TopicFeed.cshtml
+++ b/TASVideos/WikiModules/TopicFeed.cshtml
@@ -10,8 +10,8 @@
 		var collapseId = $"collapse-content-{post.Id}";
 		<div class="card-body">
 			<div>
-				<h5 condition="!Model.HideContent"><a href="/Forum/Posts/@(post.Id)">@post.Subject</a></h5>
-				<h5 condition="Model.HideContent"><a class="collapsed" data-bs-toggle="collapse" href="/Forum/Posts/@(post.Id)" data-bs-target="#@collapseId" role="button" aria-expanded="false"><i class="fa fa-chevron-circle-down"></i> @post.Subject</a></h5>
+				<h5 condition="!Model.HideContent"><a href="/Forum/Posts/@(post.Id)">@(string.IsNullOrEmpty(post.Subject) ? post.Title : post.Subject)</a></h5>
+				<h5 condition="Model.HideContent"><a class="collapsed" data-bs-toggle="collapse" href="/Forum/Posts/@(post.Id)" data-bs-target="#@collapseId" role="button" aria-expanded="false"><i class="fa fa-chevron-circle-down"></i> @(string.IsNullOrEmpty(post.Subject) ? post.Title : post.Subject)</a></h5>
 				<h6 class="card-subtitle mb-2 text-body-tertiary">
 					<small>
 						posted by <profile-link username="@post.PosterName"></profile-link> <timezone-convert asp-for="@post.CreateTimestamp" in-line="true" />

--- a/TASVideos/WikiModules/TopicFeed.cshtml.cs
+++ b/TASVideos/WikiModules/TopicFeed.cshtml.cs
@@ -1,4 +1,3 @@
-using NUglify.Helpers;
 using TASVideos.Data.Entity.Forum;
 using TASVideos.WikiEngine;
 
@@ -29,7 +28,8 @@ public class TopicFeed(ApplicationDbContext db) : WikiViewComponent
 				p.EnableBbCode,
 				p.EnableHtml,
 				p.Text,
-				p.Subject.IfNullOrWhiteSpace(p.Topic!.Title),
+				p.Subject,
+				p.Topic!.Title,
 				p.Poster!.UserName,
 				p.CreateTimestamp))
 			.Take(l ?? 5)
@@ -38,5 +38,5 @@ public class TopicFeed(ApplicationDbContext db) : WikiViewComponent
 		return View();
 	}
 
-	public record TopicPost(int Id, bool EnableBbCode, bool EnableHtml, string Text, string? Subject, string PosterName, DateTime CreateTimestamp);
+	public record TopicPost(int Id, bool EnableBbCode, bool EnableHtml, string Text, string? Subject, string Title, string PosterName, DateTime CreateTimestamp);
 }

--- a/TASVideos/WikiModules/TopicFeed.cshtml.cs
+++ b/TASVideos/WikiModules/TopicFeed.cshtml.cs
@@ -1,3 +1,4 @@
+using NUglify.Helpers;
 using TASVideos.Data.Entity.Forum;
 using TASVideos.WikiEngine;
 
@@ -28,7 +29,7 @@ public class TopicFeed(ApplicationDbContext db) : WikiViewComponent
 				p.EnableBbCode,
 				p.EnableHtml,
 				p.Text,
-				p.Subject,
+				p.Subject.IfNullOrWhiteSpace(p.Topic == null ? "" : p.Topic.Title),
 				p.Poster!.UserName,
 				p.CreateTimestamp))
 			.Take(l ?? 5)

--- a/TASVideos/WikiModules/TopicFeed.cshtml.cs
+++ b/TASVideos/WikiModules/TopicFeed.cshtml.cs
@@ -29,7 +29,7 @@ public class TopicFeed(ApplicationDbContext db) : WikiViewComponent
 				p.EnableBbCode,
 				p.EnableHtml,
 				p.Text,
-				p.Subject.IfNullOrWhiteSpace(p.Topic == null ? "" : p.Topic.Title),
+				p.Subject.IfNullOrWhiteSpace(p.Topic!.Title),
 				p.Poster!.UserName,
 				p.CreateTimestamp))
 			.Take(l ?? 5)


### PR DESCRIPTION
Resolves #2326 

The topicfeed module lists the posts in one or more topics. It titles each post using the subject line. However, the first post in a topic cannot have a subject line causing the module to display nothing.

This PR changes the module to default to the topic's title if the subject line is blank.