### PR TITLE
Add ability to designate "content type" of forum topics, extending the idea of Site News

### DIFF
--- a/TASVideos.Common/Constants.cs
+++ b/TASVideos.Common/Constants.cs
@@ -88,7 +88,6 @@ public static class ForumConstants
 {
 	public const int PostsPerPage = 25;
 	public const int WorkBenchForumId = 7;
-	public const int NewsTopicId = 8694;
 	public const int DaysPostsCountAsActive = 14;
 }
 

--- a/TASVideos.Data/Entity/Forum/ForumPost.cs
+++ b/TASVideos.Data/Entity/Forum/ForumPost.cs
@@ -47,5 +47,7 @@ public static class ForumPostQueryableExtensions
 
 		public IOrderedQueryable<ForumPost> ByWebRanking(string searchTerms)
 			=> query.OrderByDescending(p => p.SearchVector.Rank(EF.Functions.WebSearchToTsQuery(searchTerms)));
+
+		public IQueryable<ForumPost> WhereSpecialContentType() => query.Where(p => p.Topic!.ContentType != ForumTopicContentType.Regular);
 	}
 }

--- a/TASVideos.Data/Entity/Forum/ForumTopic.cs
+++ b/TASVideos.Data/Entity/Forum/ForumTopic.cs
@@ -1,10 +1,19 @@
 namespace TASVideos.Data.Entity.Forum;
 
+/// <summary>The topic type gives the topic a special display and sorting priority.</summary>
 public enum ForumTopicType
 {
 	Regular = 0,
 	Sticky = 1,
 	Announcement = 2
+}
+
+/// <summary>The content type gives topics a special status, being announced in external media publishers and shown on the front page.</summary>
+public enum ForumTopicContentType
+{
+	Regular = 0,
+	SiteNews = 1,
+	Community = 2,
 }
 
 public class ForumTopic : BaseEntity
@@ -23,6 +32,7 @@ public class ForumTopic : BaseEntity
 	public User? Poster { get; set; }
 
 	public ForumTopicType Type { get; set; }
+	public ForumTopicContentType ContentType { get; set; }
 
 	public bool IsLocked { get; set; }
 

--- a/TASVideos.Data/Migrations/20260513173238_AddTopicContentType.Designer.cs
+++ b/TASVideos.Data/Migrations/20260513173238_AddTopicContentType.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using TASVideos.Data;
 namespace TASVideos.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260513173238_AddTopicContentType")]
+    partial class AddTopicContentType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TASVideos.Data/Migrations/20260513173238_AddTopicContentType.cs
+++ b/TASVideos.Data/Migrations/20260513173238_AddTopicContentType.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TASVideos.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTopicContentType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "content_type",
+                table: "forum_topics",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "content_type",
+                table: "forum_topics");
+        }
+    }
+}

--- a/TASVideos/Pages/Forum/ForumBaseModel.cs
+++ b/TASVideos/Pages/Forum/ForumBaseModel.cs
@@ -8,6 +8,10 @@ public class BaseForumModel : BasePageModel
 		.GetValues<ForumTopicType>()
 		.ToDropDown();
 
+	protected static readonly List<SelectListItem> TopicContentTypeList = Enum
+		.GetValues<ForumTopicContentType>()
+		.ToDropDown();
+
 	protected static readonly List<SelectListItem> MoodList = [.. Enum
 		.GetValues<ForumPostMood>()
 		.Select(m => new SelectListItem
@@ -22,6 +26,7 @@ public class BaseForumModel : BasePageModel
 
 	public List<SelectListItem> Moods => MoodList;
 	public List<SelectListItem> TopicTypes => TopicTypeList;
+	public List<SelectListItem> TopicContentTypes => TopicContentTypeList;
 
 	public new RedirectToPageResult NotFound() => RedirectToPage("/Forum/NotFound");
 }

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -140,7 +140,7 @@ public class CreateModel(
 
 		var mood = Mood != ForumPostMood.Normal ? $" (Mood: {Mood})" : "";
 		var subject = string.IsNullOrWhiteSpace(Subject) ? "" : $" ({Subject})";
-		if (TopicId == ForumConstants.NewsTopicId)
+		if (topic.ContentType != ForumTopicContentType.Regular)
 		{
 			await publisher.AnnounceNewsPost(
 				$"[News Post]({{0}}) by {user.UserName}{mood}",

--- a/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Posts/Create.cshtml.cs
@@ -140,7 +140,7 @@ public class CreateModel(
 
 		var mood = Mood != ForumPostMood.Normal ? $" (Mood: {Mood})" : "";
 		var subject = string.IsNullOrWhiteSpace(Subject) ? "" : $" ({Subject})";
-		if (topic.ContentType != ForumTopicContentType.Regular)
+		if (!topic.Forum.Restricted && topic.ContentType != ForumTopicContentType.Regular)
 		{
 			await publisher.AnnounceNewsPost(
 				$"[News Post]({{0}}) by {user.UserName}{mood}",

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml
@@ -32,6 +32,7 @@
 			<label asp-for="Type"></label>
 			<select asp-for="Type" asp-items="Model.TopicTypes"></select>
 			<span asp-validation-for="Type"></span>
+			<div><small class="text-body-secondary">The Type determines the sorting priority of the topic in forums.</small></div>
 		</column>
 	</row>
 	<row>
@@ -42,6 +43,12 @@
 		</column>
 		<column md="2">
 			<mood-preview current-mood="@Model.Mood" avatar="@Model.UserAvatars"></mood-preview>
+		</column>
+		<column permission="SetTopicType" md="6">
+			<label asp-for="ContentType"></label>
+			<select asp-for="ContentType" asp-items="Model.TopicContentTypes"></select>
+			<span asp-validation-for="ContentType"></span>
+			<div><small class="text-body-secondary">Content Types other than 'Regular' give topics a special status. Their posts will be announced in external media publishers and shown on the front page.</small></div>
 		</column>
 	</row>
 	<post-helper class="mt-2"></post-helper>

--- a/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Create.cshtml.cs
@@ -24,7 +24,10 @@ public class CreateModel(
 	public string Post { get; init; } = "";
 
 	[BindProperty]
-	public ForumTopicType Type { get; init; } = ForumTopicType.Regular;
+	public ForumTopicType Type { get; set; } = ForumTopicType.Regular;
+
+	[BindProperty]
+	public ForumTopicContentType ContentType { get; set; } = ForumTopicContentType.Regular;
 
 	[BindProperty]
 	public ForumPostMood Mood { get; init; } = ForumPostMood.Normal;
@@ -103,19 +106,26 @@ public class CreateModel(
 			return NotFound();
 		}
 
+		if (!User.Has(PermissionTo.SetTopicType))
+		{
+			Type = ForumTopicType.Regular;
+			ContentType = ForumTopicContentType.Regular;
+		}
+
 		var userId = User.GetUserId();
 
 		using var dbTransaction = await db.BeginTransactionAsync();
 		var topic = db.ForumTopics.Add(new ForumTopic
 		{
 			Type = Type,
+			ContentType = ContentType,
 			Title = Title,
 			PosterId = userId,
 			ForumId = ForumId
 		}).Entity;
 		await db.SaveChangesAsync();
 
-		await forumService.CreatePost(new PostCreate(
+		var postId = await forumService.CreatePost(new PostCreate(
 			ForumId, topic.Id, null, Post, userId, User.Name(), Mood, IpAddress, WatchTopic));
 
 		if (User.Has(PermissionTo.CreateForumPolls) && Poll.IsValid)
@@ -128,11 +138,23 @@ public class CreateModel(
 		await userManager.AssignAutoAssignableRolesByPost(User.GetUserId());
 		await dbTransaction.CommitAsync();
 
-		await publisher.SendForum(
-			forum.Restricted,
-			$"[New Topic]({{0}}) by {User.Name()}",
-			$"{forum.ShortName}: {Title}",
-			$"Forum/Topics/{topic.Id}");
+		if (topic.ContentType == ForumTopicContentType.Regular)
+		{
+			await publisher.SendForum(
+				forum.Restricted,
+				$"[New Topic]({{0}}) by {User.Name()}",
+				$"{forum.ShortName}: {Title}",
+				$"Forum/Topics/{topic.Id}");
+		}
+		else
+		{
+			var mood = Mood != ForumPostMood.Normal ? $" (Mood: {Mood})" : "";
+
+			await publisher.AnnounceNewsPost(
+				$"[News Post]({{0}}) by {User.Name()}{mood}",
+				$"{forum.ShortName}: {topic.Title}",
+				postId);
+		}
 
 		return RedirectToPage("Index", new { topic.Id });
 	}

--- a/TASVideos/Pages/Forum/Topics/SetType.cshtml
+++ b/TASVideos/Pages/Forum/Topics/SetType.cshtml
@@ -1,10 +1,10 @@
 @page "{topicId}"
 @model SetTypeModel
 @{
-	ViewData.SetTitle($"Setting type for topic for: {Model.TopicTitle}");
+	ViewData.SetTitle($"Setting types for topic: {Model.TopicTitle}");
 }
 @section PageTitle {
-	Setting type for topic: <a asp-page="/Forum/Subforum/Index" asp-route-id="@Model.ForumId">@Model.ForumName</a> →
+	Setting types for topic: <a asp-page="/Forum/Subforum/Index" asp-route-id="@Model.ForumId">@Model.ForumName</a> →
 	<a asp-page="/Forum/Topics/Index" asp-route-id="@Model.TopicId">@Model.TopicTitle</a>
 }
 
@@ -12,11 +12,20 @@
 	<input type="hidden" asp-for="ForumId"/>
 	<input type="hidden" asp-for="ForumName" />
 	<input type="hidden" asp-for="TopicTitle"/>
-	<row>
+	<row class="mb-2">
 		<column md="6">
 			<label asp-for="Type"></label>
 			<select asp-for="Type" asp-items="Model.TopicTypes"></select>
 			<span asp-validation-for="Type"></span>
+			<div><small class="text-body-secondary">The Type determines the sorting priority of the topic in forums.</small></div>
+		</column>
+	</row>
+	<row>
+		<column md="6">
+			<label asp-for="ContentType"></label>
+			<select asp-for="ContentType" asp-items="Model.TopicContentTypes"></select>
+			<span asp-validation-for="ContentType"></span>
+			<div><small class="text-body-secondary">Content Types other than 'Regular' give topics a special status. Their posts will be announced in external media publishers and shown on the front page.</small></div>
 		</column>
 	</row>
 	<form-button-bar>

--- a/TASVideos/Pages/Forum/Topics/SetType.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/SetType.cshtml.cs
@@ -12,6 +12,9 @@ public class SetTypeModel(ApplicationDbContext db) : BaseForumModel
 	public ForumTopicType Type { get; set; }
 
 	[BindProperty]
+	public ForumTopicContentType ContentType { get; set; }
+
+	[BindProperty]
 	public string TopicTitle { get; set; } = "";
 
 	[BindProperty]
@@ -37,6 +40,7 @@ public class SetTypeModel(ApplicationDbContext db) : BaseForumModel
 
 		TopicTitle = topic.Title;
 		Type = topic.Type;
+		ContentType = topic.ContentType;
 		ForumId = topic.ForumId;
 		ForumName = topic.Forum!.Name;
 		return Page();
@@ -59,8 +63,9 @@ public class SetTypeModel(ApplicationDbContext db) : BaseForumModel
 		}
 
 		topic.Type = Type;
+		topic.ContentType = ContentType;
 
-		SetMessage(await db.TrySaveChanges(), $"Topic set to {Type}", "Unable to set the topic type");
+		SetMessage(await db.TrySaveChanges(), $"Topic set to Type '{Type}' and Content Type '{ContentType}'", "Unable to set the topic types");
 		return RedirectToPage("Index", new { topic.Id });
 	}
 }

--- a/TASVideos/Pages/Forum/Topics/Split.cshtml.cs
+++ b/TASVideos/Pages/Forum/Topics/Split.cshtml.cs
@@ -94,6 +94,7 @@ public class SplitModel(
 		var newTopic = db.ForumTopics.Add(new ForumTopic
 		{
 			Type = ForumTopicType.Regular,
+			ContentType = ForumTopicContentType.Regular,
 			Title = Topic.NewTopicName,
 			PosterId = User.GetUserId(),
 			ForumId = Topic.CreateNewTopicIn

--- a/TASVideos/Pages/RssFeeds/News.cshtml
+++ b/TASVideos/Pages/RssFeeds/News.cshtml
@@ -16,7 +16,7 @@
 		{
 			var postUrl = $"{Settings.BaseUrl}/Forum/Posts/{news.PostId}";
 			<item>
-				<title>@news.Subject</title>
+				<title>@(string.IsNullOrEmpty(news.Subject) ? news.Title : news.Subject)</title>
 				<rss-link>@postUrl</rss-link>
 				<description>
 					<html-encode>

--- a/TASVideos/Pages/RssFeeds/News.cshtml.cs
+++ b/TASVideos/Pages/RssFeeds/News.cshtml.cs
@@ -5,14 +5,12 @@ namespace TASVideos.Pages.RssFeeds;
 [ResponseCache(Duration = 1200)]
 public class NewsModel(ApplicationDbContext db) : BasePageModel
 {
-	private const int NewsTopicId = 8694; // Unfortunately, there is not an easy way to not hard code this
-
 	public List<RssNews> News { get; set; } = [];
 
 	public async Task<IActionResult> OnGet()
 	{
 		News = await db.ForumPosts
-			.ForTopic(NewsTopicId)
+			.WhereSpecialContentType()
 			.ByMostRecent()
 			.Select(p => new RssNews(
 				p.Id,

--- a/TASVideos/Pages/RssFeeds/News.cshtml.cs
+++ b/TASVideos/Pages/RssFeeds/News.cshtml.cs
@@ -15,6 +15,7 @@ public class NewsModel(ApplicationDbContext db) : BasePageModel
 			.Select(p => new RssNews(
 				p.Id,
 				p.LastUpdateTimestamp,
+				p.Topic!.Title,
 				p.Subject ?? "",
 				p.Text,
 				p.EnableHtml,
@@ -24,5 +25,5 @@ public class NewsModel(ApplicationDbContext db) : BasePageModel
 		return Rss();
 	}
 
-	public record RssNews(int PostId, DateTime PubDate, string Subject, string Text, bool EnableHtml, bool EnableBbCode);
+	public record RssNews(int PostId, DateTime PubDate, string Title, string Subject, string Text, bool EnableHtml, bool EnableBbCode);
 }

--- a/TASVideos/WikiModules/TopicFeed.cshtml.cs
+++ b/TASVideos/WikiModules/TopicFeed.cshtml.cs
@@ -12,15 +12,20 @@ public class TopicFeed(ApplicationDbContext db) : WikiViewComponent
 	public string? WikiLink { get; set; }
 	public List<TopicPost> Posts { get; set; } = [];
 
-	public async Task<IViewComponentResult> InvokeAsync(int? l, IList<int> t, bool right, string? heading, bool hideContent, string wikiLink)
+	public async Task<IViewComponentResult> InvokeAsync(int? l, IList<int> t, bool right, string? heading, bool hideContent, string wikiLink, bool specialTopics)
 	{
 		Heading = heading;
 		RightAlign = right;
 		HideContent = hideContent;
 		WikiLink = wikiLink;
 
-		Posts = await db.ForumPosts
-			.Where(p => p.TopicId != null && t.Contains(p.TopicId.Value))
+		IQueryable<ForumPost> query = db.ForumPosts;
+
+		query = specialTopics
+			? query.WhereSpecialContentType()
+			: query.Where(p => p.TopicId != null && t.Contains(p.TopicId.Value));
+
+		Posts = await query
 			.ExcludeRestricted(false) // By design, let's not allow restricted topics as wiki feeds
 			.ByMostRecent()
 			.Select(p => new TopicPost(

--- a/tests/TASVideos.RazorPages.Tests/Pages/Forum/Topics/CreateModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Forum/Topics/CreateModelTests.cs
@@ -193,10 +193,11 @@ public class CreateModelTests : BasePageModelTests
 			Title = "Test Topic Title",
 			Post = "This is a test post content",
 			Type = ForumTopicType.Sticky,
+			ContentType = ForumTopicContentType.Community,
 			WatchTopic = true,
 			Mood = ForumPostMood.Playful
 		};
-		AddAuthenticatedUser(createModel, user, [PermissionTo.CreateForumTopics]);
+		AddAuthenticatedUser(createModel, user, [PermissionTo.CreateForumTopics, PermissionTo.SetTopicType]);
 
 		var result = await createModel.OnPost();
 
@@ -207,6 +208,7 @@ public class CreateModelTests : BasePageModelTests
 		Assert.AreEqual(forum.Id, createdTopic.ForumId);
 		Assert.AreEqual(user.Id, createdTopic.PosterId);
 		Assert.AreEqual(ForumTopicType.Sticky, createdTopic.Type);
+		Assert.AreEqual(ForumTopicContentType.Community, createdTopic.ContentType);
 
 		await _userManager.Received(1).AssignAutoAssignableRolesByPost(user.Id);
 		await _publisher.Received(1).Send(Arg.Any<IPostable>());


### PR DESCRIPTION
Those with permission to set types of topics (Announcement, Sticky) can now also set the Content Type of the topic.
'Regular' is the default, and for now, we have 'SiteNews' and 'Community', but currently both act exactly the same.
- When making a post in a topic of these types, an Announcement will go out to our external medial publishers (Discord, IRC, Bluesky), like previously only happened with News Posts in a hard-coded topic id.
- Additionally the news.rss feed also includes those posts.
- I also added a new option in the `topicfeed` module in our wiki, "specialTopics", which shows posts from those topics without having to edit the wiki with the new IDs all the time.

The new "Content Type":
<img width="882" height="315" alt="image" src="https://github.com/user-attachments/assets/93431a52-25c6-4da1-a0ae-00311b1336cc" />
