### PR TITLE
Hotfix against submissions expecting a zipped file from the movie parser

### DIFF
--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -68,9 +68,18 @@ public interface IQueueService
 	Task<ObsoletePublicationResult?> GetObsoletePublicationTags(int publicationId);
 
 	/// <summary>
-	/// Parses an individual movie file and returns the parse result along with the movie file bytes
+	/// Parses an individual movie file and returns the parse result along with the movie file bytes.
+	/// <see cref="IFormFile"/> may be gzipped, but <see cref="IFormFile.FileName"/> must not have a .gz extension
+	/// <returns>The parse result and the raw movie file (after potential un-gzipping)</returns>
 	/// </summary>
 	Task<(IParseResult ParseResult, byte[] MovieFileBytes)> ParseMovieFile(IFormFile movieFile);
+
+	/// <summary>
+	/// Parses an individual movie file and returns the parse result along with the zipped movie file bytes.
+	/// <see cref="IFormFile"/> may be gzipped, but <see cref="IFormFile.FileName"/> must not have a .gz extension
+	/// <returns>The parse result and the raw movie file (after potential un-gzipping) placed into a .zip file</returns>
+	/// </summary>
+	Task<(IParseResult ParseResult, byte[] ZippedMovieFileBytes)> ParseMovieFileAndZip(IFormFile movieFile);
 
 	/// <summary>
 	/// Claims a submission for judging by the specified user
@@ -332,7 +341,7 @@ internal class QueueService(
 
 		if (request.ReplaceMovieFile is not null)
 		{
-			var (parseResult, movieFileBytes) = await ParseMovieFile(request.ReplaceMovieFile);
+			var (parseResult, zippedMovieFileBytes) = await ParseMovieFileAndZip(request.ReplaceMovieFile);
 			if (!parseResult.Success)
 			{
 				return UpdateSubmissionResult.Error("Movie file parsing failed");
@@ -360,7 +369,7 @@ internal class QueueService(
 			submission.Warnings = mapResult.Warnings;
 			submission.SystemFrameRate = mapResult.SystemFrameRate;
 
-			submission.MovieFile = movieFileBytes;
+			submission.MovieFile = zippedMovieFileBytes;
 			submission.SyncedOn = null;
 			submission.SyncedByUserId = null;
 
@@ -526,6 +535,13 @@ internal class QueueService(
 		var movieFileBytes = fileStream.ToArray();
 
 		return (parseResult, movieFileBytes);
+	}
+
+	public async Task<(IParseResult ParseResult, byte[] ZippedMovieFileBytes)> ParseMovieFileAndZip(IFormFile movieFile)
+	{
+		var (parseResult, movieFileBytes) = await ParseMovieFile(movieFile);
+		var zippedMovieFileBytes = await fileService.ZipFile(movieFileBytes, movieFile.FileName);
+		return (parseResult, zippedMovieFileBytes);
 	}
 
 	public Task<ClaimSubmissionResult> ClaimForJudging(int submissionId, int userId, string userName)

--- a/TASVideos/Pages/Submissions/Submit.cshtml.cs
+++ b/TASVideos/Pages/Submissions/Submit.cshtml.cs
@@ -102,7 +102,7 @@ public class SubmitModel(
 			return Page();
 		}
 
-		var (parseResult, movieFileBytes) = await queueService.ParseMovieFile(MovieFile!);
+		var (parseResult, zippedMovieFileBytes) = await queueService.ParseMovieFileAndZip(MovieFile!);
 		if (!parseResult.Success)
 		{
 			ModelState.AddParseErrors(parseResult);
@@ -126,7 +126,7 @@ public class SubmitModel(
 			Authors,
 			ExternalAuthors,
 			Markup,
-			movieFileBytes,
+			zippedMovieFileBytes,
 			parseResult,
 			await userManager.GetRequiredUser(User));
 

--- a/tests/TASVideos.RazorPages.Tests/Pages/Submissions/SubmitModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Submissions/SubmitModelTests.cs
@@ -220,7 +220,7 @@ public class SubmitModelTests : TestDbBase
 		parseResult.Success.Returns(true);
 		parseResult.FileExtension.Returns("bk2");
 
-		_queueService.ParseMovieFileOrZip(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
+		_queueService.ParseMovieFileAndZip(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
 		_userManager.GetRequiredUser(Arg.Any<ClaimsPrincipal>()).Returns(user);
 		_userManager.Exists("TestUser").Returns(true); // Add this line to make validation pass
 		_movieFormatDeprecator.IsDeprecated(".bk2").Returns(false);

--- a/tests/TASVideos.RazorPages.Tests/Pages/Submissions/SubmitModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Submissions/SubmitModelTests.cs
@@ -173,7 +173,7 @@ public class SubmitModelTests : TestDbBase
 		parseResult.Success.Returns(true);
 		parseResult.FileExtension.Returns("bk2");
 
-		_queueService.ParseMovieFile(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
+		_queueService.ParseMovieFileAndZip(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
 		_userManager.GetRequiredUser(Arg.Any<ClaimsPrincipal>()).Returns(user);
 		_userManager.Exists("TestUser").Returns(true);
 		_movieFormatDeprecator.IsDeprecated(".bk2").Returns(false);
@@ -220,7 +220,7 @@ public class SubmitModelTests : TestDbBase
 		parseResult.Success.Returns(true);
 		parseResult.FileExtension.Returns("bk2");
 
-		_queueService.ParseMovieFile(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
+		_queueService.ParseMovieFileOrZip(Arg.Any<IFormFile>()).Returns((parseResult, new byte[] { 1, 2, 3 }));
 		_userManager.GetRequiredUser(Arg.Any<ClaimsPrincipal>()).Returns(user);
 		_userManager.Exists("TestUser").Returns(true); // Add this line to make validation pass
 		_movieFormatDeprecator.IsDeprecated(".bk2").Returns(false);


### PR DESCRIPTION
Ideally we should just be doing the same thing we do with userfiles and additional movie files, gzip to the max and automatically un-gzip via Content-Encoding, with fallbacks for the old .zip files again with Content-Encoding, but that involves some deeper changes and this submission bug needs to be quickly fixed.