### PR TITLE
add pre/wrap to game version notes

### DIFF
--- a/TASVideos/Pages/Games/Versions/View.cshtml
+++ b/TASVideos/Pages/Games/Versions/View.cshtml
@@ -76,7 +76,7 @@
 		<row condition="!string.IsNullOrWhiteSpace(Model.Version.Notes)" class="mt-2">
 			<column sm="12">
 				<h4>Notes</h4>
-				@Model.Version.Notes
+				<pre style="white-space: pre-wrap">@Model.Version.Notes</pre>
 			</column>
 		</row>
 	</card-body>


### PR DESCRIPTION
similar to annotations view

before

<img width="774" height="139" alt="изображение" src="https://github.com/user-attachments/assets/df9e0026-45ed-4480-a136-dca3742c57b5" />

after

<img width="720" height="206" alt="изображение" src="https://github.com/user-attachments/assets/5b70a311-fd80-47fb-ae94-ecf17314c337" />
