### PR TITLE
force wrapping on some table columns

### DIFF
--- a/TASVideos/Pages/Flags/Index.cshtml
+++ b/TASVideos/Pages/Flags/Index.cshtml
@@ -13,10 +13,10 @@
 	{
 		<tr>
 			<td>@flag.Name</td>
-			<td>@flag.IconPath</td>
-			<td>@flag.LinkPath</td>
-			<td>@flag.Token</td>
-			<td>@flag.PermissionRestriction</td>
+			<td style="overflow-wrap: anywhere">@flag.IconPath</td>
+			<td style="overflow-wrap: anywhere">@flag.LinkPath</td>
+			<td style="overflow-wrap: anywhere">@flag.Token</td>
+			<td style="overflow-wrap: anywhere">@flag.PermissionRestriction</td>
 			<td>@flag.Weight</td>
 			<td-action-column>
 				<edit-link asp-page="Edit" asp-route-id="@flag.Id"></edit-link>

--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -230,9 +230,9 @@
 			<td>@version.Region</td>
 			<td>@version.Version</td>
 			<td>@version.SystemCode</td>
-			<td>
-				<small condition="!string.IsNullOrWhiteSpace(version.Sha1)" class="text-nowrap">SHA1: @version.Sha1</small><br />
-				<small condition="!string.IsNullOrWhiteSpace(version.Md5)" class="text-nowrap">MD5: @version.Md5</small>
+			<td style="overflow-wrap: anywhere">
+				<small condition="!string.IsNullOrWhiteSpace(version.Sha1)">SHA1: @version.Sha1</small><br />
+				<small condition="!string.IsNullOrWhiteSpace(version.Md5)">MD5: @version.Md5</small>
 			</td>
 		</tr>
 	}

--- a/TASVideos/Pages/Games/Versions/List.cshtml
+++ b/TASVideos/Pages/Games/Versions/List.cshtml
@@ -30,20 +30,22 @@
 			<td>@version.TitleOverride</td>
 			<td>@version.Version</td>
 			<td>@version.Region</td>
-			<td>
-				<small condition="!string.IsNullOrEmpty(version.Sha1)" class="text-nowrap">SHA1: @version.Sha1</small>
-				<small condition="!string.IsNullOrEmpty(version.Md5)" class="text-nowrap">MD5: @version.Md5</small><br />
+			<td style="overflow-wrap: anywhere">
+				<small condition="!string.IsNullOrEmpty(version.Sha1)">SHA1: @version.Sha1</small><br />
+				<small condition="!string.IsNullOrEmpty(version.Md5)">MD5: @version.Md5</small>
 			</td>
 			<td>@version.System</td>
 			<td-action-column>
-				<a
-					class="btn btn-secondary btn-sm"
-					asp-page="/Games/Versions/View"
-					asp-route-gameId="@Model.GameId"
-					asp-route-id="@version.Id">
-					<i class="fa fa-eye"></i> View
-				</a>
-				<edit-link class="btn-sm" asp-page="Edit" permission="CatalogMovies" asp-route-id="@version.Id" asp-route-gameId="@Model.GameId"></edit-link>
+				<div class="d-flex flex-wrap gap-1">
+					<a
+						class="btn btn-secondary btn-sm"
+						asp-page="/Games/Versions/View"
+						asp-route-gameId="@Model.GameId"
+						asp-route-id="@version.Id">
+						<i class="fa fa-eye"></i> View
+					</a>
+					<edit-link class="btn-sm" asp-page="Edit" permission="CatalogMovies" asp-route-id="@version.Id" asp-route-gameId="@Model.GameId"></edit-link>
+				</div>
 			</td-action-column>
 		</tr>
 	}

--- a/TASVideos/Pages/Wiki/PageHistory.cshtml
+++ b/TASVideos/Pages/Wiki/PageHistory.cshtml
@@ -48,7 +48,7 @@
 				<td><timezone-convert asp-for="@revision.CreateTimestamp" /></td>
 				<td><profile-link username="@revision.CreateUserName"></profile-link></td>
 				<td>@revision.MinorEdit</td>
-				<td>@revision.RevisionMessage</td>
+				<td style="overflow-wrap: anywhere">@revision.RevisionMessage</td>
 				<td>@revision.Length&nbsp;<span condition="lengthDelta.HasValue" class="@lengthDeltaClassColor @lengthDeltaClassBold">(@lengthDelta!.Value.ToString("+0;-0;0"))</span></td>
 				<td style="min-width: 100px">
 					<div class="btn-group" role="button" aria-label="diff picker">


### PR DESCRIPTION
if there are buttons on the far right and some huge "words" in the middle, buttons get scrolled away on anything smaller than desktop fullscreen view. version list has 2 buttons so I made them wrap too.

fixes #2341

before

<img width="745" height="490" alt="изображение" src="https://github.com/user-attachments/assets/bb3aca5a-9d1b-4c78-b4a3-c92b2efa0109" />

<img width="731" height="374" alt="изображение" src="https://github.com/user-attachments/assets/e8d60da5-9347-48e8-8081-681bb14a9276" />


after

<img width="748" height="620" alt="изображение" src="https://github.com/user-attachments/assets/0c5a63ed-74b8-47b8-a517-444bcf4e6920" />

<img width="716" height="417" alt="изображение" src="https://github.com/user-attachments/assets/62e81291-d6e4-4cf9-a97d-6323863736fb" />

hashes can still be copied if you select them fully, and they won't contain linebreaks

https://tasvideos.org/MediaPosts is similar but has no buttons and nobody uses it, so I didn't bother

https://tasvideos.org/Subs-List looks awful if I force wrapping, so the proper solution is turning them into custom cards of some kind, like on the front page.