### PR TITLE
use World region for non-tv-based systems in parsers

### DIFF
--- a/TASVideos.Parsers/Parsers/Bk2.cs
+++ b/TASVideos.Parsers/Parsers/Bk2.cs
@@ -115,6 +115,12 @@ internal class Bk2 : Parser, IParser
 				platform = systemId;
 			}
 
+			// dosbox-x core can run several non-tv-based systems in addition to dos
+			if (platform == SystemCodes.Dos)
+			{
+				result.Region = RegionType.World;
+			}
+
 			// Check various subsystem flags
 			if (header.GetBoolFor(Keys.Mode32X))
 			{

--- a/TASVideos.Parsers/Parsers/Ctas.cs
+++ b/TASVideos.Parsers/Parsers/Ctas.cs
@@ -9,7 +9,7 @@ internal class Ctas : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.Pc,
 			FrameRateOverride = FrameRate
 		};

--- a/TASVideos.Parsers/Parsers/Dft.cs
+++ b/TASVideos.Parsers/Parsers/Dft.cs
@@ -11,7 +11,7 @@ internal class Dft : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.Pc,
 			FrameRateOverride = FrameRate,
 		};

--- a/TASVideos.Parsers/Parsers/Dsm.cs
+++ b/TASVideos.Parsers/Parsers/Dsm.cs
@@ -7,7 +7,7 @@ internal class Dsm : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.Ds
 		};
 

--- a/TASVideos.Parsers/Parsers/Jrsr.cs
+++ b/TASVideos.Parsers/Parsers/Jrsr.cs
@@ -61,7 +61,7 @@ internal class Jrsr : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.Dos
 		};
 

--- a/TASVideos.Parsers/Parsers/Lmp.cs
+++ b/TASVideos.Parsers/Parsers/Lmp.cs
@@ -21,7 +21,7 @@ internal class Lmp : Parser, IParser
 	private const int Maxplayers = 4;
 	private const int Terminator = 0x80;
 	private const int Invalid = -1;
-	private const double NtscDoomFramerate = 35.0029869215506;
+	private const double DoomFramerate = 35.0029869215506;
 
 	private int FooterPointer { get; set; } = Invalid;
 
@@ -349,9 +349,9 @@ internal class Lmp : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.Pc,
-			FrameRateOverride = NtscDoomFramerate
+			FrameRateOverride = DoomFramerate
 		};
 
 		/* A lmp consists of a header, inputs, and a terminator byte

--- a/TASVideos.Parsers/Parsers/Lsmv.cs
+++ b/TASVideos.Parsers/Parsers/Lsmv.cs
@@ -80,12 +80,12 @@ internal class Lsmv : Parser, IParser
 						break;
 					case "gdmg":
 						result.SystemCode = SystemCodes.GameBoy;
-						result.Region = RegionType.Ntsc;
+						result.Region = RegionType.World;
 						break;
 					case "ggbc":
 					case "ggbca":
 						result.SystemCode = SystemCodes.Gbc;
-						result.Region = RegionType.Ntsc;
+						result.Region = RegionType.World;
 						break;
 				}
 			}

--- a/TASVideos.Parsers/Parsers/Ltm.cs
+++ b/TASVideos.Parsers/Parsers/Ltm.cs
@@ -23,7 +23,7 @@ internal class Ltm : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.Pc
 		};
 

--- a/TASVideos.Parsers/Parsers/Tas.cs
+++ b/TASVideos.Parsers/Parsers/Tas.cs
@@ -12,7 +12,7 @@ internal class Tas : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.Pc,
 			FrameRateOverride = 1000.0 / 17.0
 		};

--- a/TASVideos.Parsers/Parsers/Vbm.cs
+++ b/TASVideos.Parsers/Parsers/Vbm.cs
@@ -7,7 +7,7 @@ internal class Vbm : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.GameBoy
 		};
 

--- a/TASVideos.Parsers/Parsers/Wtf.cs
+++ b/TASVideos.Parsers/Parsers/Wtf.cs
@@ -7,7 +7,7 @@ internal class Wtf : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.World,
 			SystemCode = SystemCodes.Pc,
 			Frames = (int)((length - 1024) / 8)
 		};

--- a/TASVideos.Parsers/Result/Enums.cs
+++ b/TASVideos.Parsers/Result/Enums.cs
@@ -19,7 +19,12 @@ public enum RegionType
 	/// <summary>
 	/// Indicates that the region is the PAL standard
 	/// </summary>
-	Pal
+	Pal,
+
+	/// <summary>
+	/// Indicates the system is not TV based
+	/// </summary>
+	World
 }
 
 /// <summary>

--- a/tests/TASVideos.MovieParsers.Tests/Bk2ParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/Bk2ParserTests.cs
@@ -381,6 +381,7 @@ public class Bk2ParserTests : BaseParserTests
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(420782, result.Frames);
 		Assert.AreEqual(1000, result.FrameRateOverride);
+		Assert.AreEqual(RegionType.World, result.Region);
 		Assert.IsNull(result.CycleCount);
 		AssertNoWarningsOrErrors(result);
 	}

--- a/tests/TASVideos.MovieParsers.Tests/DftTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/DftTests.cs
@@ -27,12 +27,12 @@ public class DftTests : BaseParserTests
 	}
 
 	[TestMethod]
-	public async Task Ntsc()
+	public async Task World()
 	{
 		var result = await _dftParser.Parse(Embedded("2frames.dft", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.World, result.Region);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/LsmvTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/LsmvTests.cs
@@ -108,9 +108,9 @@ public class LsmvTests : BaseParserTests
 	[DataRow("gametype-sufamiturbo.lsmv", SystemCodes.Snes, RegionType.Ntsc)]
 	[DataRow("gametype-sgb_ntsc.lsmv", SystemCodes.Sgb, RegionType.Ntsc)]
 	[DataRow("gametype-sgb_pal.lsmv", SystemCodes.Sgb, RegionType.Pal)]
-	[DataRow("gametype-gdmg.lsmv", SystemCodes.GameBoy, RegionType.Ntsc)]
-	[DataRow("gametype-ggbc.lsmv", SystemCodes.Gbc, RegionType.Ntsc)]
-	[DataRow("gametype-ggbca.lsmv", SystemCodes.Gbc, RegionType.Ntsc)]
+	[DataRow("gametype-gdmg.lsmv", SystemCodes.GameBoy, RegionType.World)]
+	[DataRow("gametype-ggbc.lsmv", SystemCodes.Gbc, RegionType.World)]
+	[DataRow("gametype-ggbca.lsmv", SystemCodes.Gbc, RegionType.World)]
 	public async Task SystemAndRegion(string file, string expectedSystem, RegionType expectedRegion)
 	{
 		var result = await _lsmvParser.Parse(Embedded(file, out var length), length);

--- a/tests/TASVideos.MovieParsers.Tests/LtmTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/LtmTests.cs
@@ -47,7 +47,7 @@ public class LtmTests : BaseParserTests
 		var result = await _ltmParser.Parse(Embedded("2frames.ltm", out var length), length);
 
 		Assert.IsTrue(result.Success);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.World, result.Region);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/VbmTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/VbmTests.cs
@@ -26,12 +26,12 @@ public class VbmTests : BaseParserTests
 	}
 
 	[TestMethod]
-	public async Task Ntsc()
+	public async Task World()
 	{
 		var result = await _vbmParser.Parse(Embedded("2frames.vbm", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.World, result.Region);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/WtfTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/WtfTests.cs
@@ -44,12 +44,12 @@ public class WtfTests : BaseParserTests
 	}
 
 	[TestMethod]
-	public async Task Ntsc()
+	public async Task World()
 	{
 		var result = await _wtfParser.Parse(Embedded("2frames.wtf", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.World, result.Region);
 	}
 
 	[TestMethod]


### PR DESCRIPTION
see #1539

ideally when creating framerates, the region field should be a drop-down and not a free string. I entered World in the past and it broke the whole site, because apparently a magic word was needed.

I wonder if merging this will also break things unless I update framerates on the site at the same moment?