### PR TITLE
region fixes for framerate creation

### DIFF
--- a/TASVideos.Core/Services/QueueService.cs
+++ b/TASVideos.Core/Services/QueueService.cs
@@ -896,7 +896,7 @@ internal class QueueService(
 				{
 					System = system,
 					FrameRate = parseResult.FrameRateOverride.Value,
-					RegionCode = parseResult.Region.ToString().ToUpper()
+					RegionCode = parseResult.Region.ToString()
 				};
 				db.GameSystemFrameRates.Add(frameRate);
 				await db.SaveChangesAsync();
@@ -910,7 +910,7 @@ internal class QueueService(
 			// Those systems should never hit this code block.  But just in case.
 			systemFrameRate = await db.GameSystemFrameRates
 				.ForSystem(system.Id)
-				.ForRegion(parseResult.Region.ToString().ToUpper())
+				.ForRegion(parseResult.Region.ToString())
 				.FirstOrDefaultAsync();
 		}
 

--- a/TASVideos.Parsers/Parsers/Bk2.cs
+++ b/TASVideos.Parsers/Parsers/Bk2.cs
@@ -33,7 +33,7 @@ internal class Bk2 : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc
+			Region = RegionType.NTSC
 		};
 
 		var archive = await file.OpenZipArchiveRead();
@@ -106,7 +106,7 @@ internal class Bk2 : Parser, IParser
 
 			if (header.GetBoolFor(Keys.Pal))
 			{
-				result.Region = RegionType.Pal;
+				result.Region = RegionType.PAL;
 			}
 
 			// Some biz system ids do not match tasvideos, convert if needed
@@ -147,7 +147,7 @@ internal class Bk2 : Parser, IParser
 			else if (header.GetValueFor(Keys.Board) == SystemCodes.Sgb)
 			{
 				platform = SystemCodes.Sgb;
-				result.FrameRateOverride = result.Region == RegionType.Pal
+				result.FrameRateOverride = result.Region == RegionType.PAL
 					? PalSnesFramerate
 					: NtscSnesFramerate;
 			}
@@ -229,7 +229,7 @@ internal class Bk2 : Parser, IParser
 		// MapParsedResult() implies we only ever have a list of framerates for cores with framerate overrides, but it doesn't distinguish by core. nymashock has cycle count but octoshock has to rely on mednafen framerates for now. so we override with a constant for octoshock, to prevent picking random wrong values from nymashock overrides
 		if (core == "octoshock")
 		{
-			result.FrameRateOverride = result.Region == RegionType.Pal
+			result.FrameRateOverride = result.Region == RegionType.PAL
 				? PalPsxFramerate
 				: NtscPsxFramerate;
 		}

--- a/TASVideos.Parsers/Parsers/Ctm.cs
+++ b/TASVideos.Parsers/Parsers/Ctm.cs
@@ -10,7 +10,7 @@ internal class Ctm : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.N3ds
 		};
 

--- a/TASVideos.Parsers/Parsers/Dtm.cs
+++ b/TASVideos.Parsers/Parsers/Dtm.cs
@@ -10,7 +10,7 @@ internal class Dtm : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.GameCube
 		};
 
@@ -59,7 +59,7 @@ internal class Dtm : Parser, IParser
 		br.ReadByte(); // PAL60 setting (this setting only applies to Wii games that support both 50 Hz and 60 Hz)
 		br.ReadBytes(12); // Reserved
 		br.ReadBytes(40); // Name of second disc iso
-		br.ReadBytes(20); // SHA-1 has of git revision
+		br.ReadBytes(20); // SHA-1 hash of git revision
 		br.ReadBytes(4); // DSP
 		br.ReadBytes(4); // DSP
 		result.CycleCount = br.ReadInt64(); // (486 MHz when a GameCube game is running, 729 MHz when a Wii game is running)

--- a/TASVideos.Parsers/Parsers/Fbm.cs
+++ b/TASVideos.Parsers/Parsers/Fbm.cs
@@ -7,7 +7,7 @@ internal class Fbm : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.Arcade
 		};
 

--- a/TASVideos.Parsers/Parsers/Fm2.cs
+++ b/TASVideos.Parsers/Parsers/Fm2.cs
@@ -9,7 +9,7 @@ internal class Fm2 : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.Nes
 		};
 
@@ -49,7 +49,7 @@ internal class Fm2 : Parser, IParser
 
 		if (header.GetBoolFor(Keys.Pal))
 		{
-			result.Region = RegionType.Pal;
+			result.Region = RegionType.PAL;
 		}
 
 		if (header.HasValue(Keys.StartsFromSavestate))

--- a/TASVideos.Parsers/Parsers/Fm3.cs
+++ b/TASVideos.Parsers/Parsers/Fm3.cs
@@ -9,7 +9,7 @@ internal class Fm3 : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.Nes
 		};
 
@@ -81,7 +81,7 @@ internal class Fm3 : Parser, IParser
 		// Handle region detection
 		if (header.GetBoolFor(Keys.Pal))
 		{
-			result.Region = RegionType.Pal;
+			result.Region = RegionType.PAL;
 		}
 
 		// Handle start type

--- a/TASVideos.Parsers/Parsers/Gmv.cs
+++ b/TASVideos.Parsers/Parsers/Gmv.cs
@@ -7,7 +7,7 @@ internal class Gmv : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.Genesis
 		};
 
@@ -24,7 +24,7 @@ internal class Gmv : Parser, IParser
 
 		if (flags.Bit(7))
 		{
-			result.Region = RegionType.Pal;
+			result.Region = RegionType.PAL;
 		}
 
 		if (flags.Bit(6))

--- a/TASVideos.Parsers/Parsers/Gzm.cs
+++ b/TASVideos.Parsers/Parsers/Gzm.cs
@@ -10,7 +10,7 @@ internal class Gzm : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.N64,
 			FrameRateOverride = FrameRate
 		};

--- a/TASVideos.Parsers/Parsers/Lsmv.cs
+++ b/TASVideos.Parsers/Parsers/Lsmv.cs
@@ -14,7 +14,7 @@ internal class Lsmv : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc
+			Region = RegionType.NTSC
 		};
 
 		var archive = await file.OpenZipArchiveRead();
@@ -64,19 +64,19 @@ internal class Lsmv : Parser, IParser
 					case "bsxslotted":
 					case "sufamiturbo":
 						result.SystemCode = SystemCodes.Snes;
-						result.Region = RegionType.Ntsc;
+						result.Region = RegionType.NTSC;
 						break;
 					case "snes_pal":
 						result.SystemCode = SystemCodes.Snes;
-						result.Region = RegionType.Pal;
+						result.Region = RegionType.PAL;
 						break;
 					case "sgb_ntsc":
 						result.SystemCode = SystemCodes.Sgb;
-						result.Region = RegionType.Ntsc;
+						result.Region = RegionType.NTSC;
 						break;
 					case "sgb_pal":
 						result.SystemCode = SystemCodes.Sgb;
-						result.Region = RegionType.Pal;
+						result.Region = RegionType.PAL;
 						break;
 					case "gdmg":
 						result.SystemCode = SystemCodes.GameBoy;
@@ -150,7 +150,7 @@ internal class Lsmv : Parser, IParser
 	private static void DefaultGameType(SuccessResult result)
 	{
 		result.SystemCode = SystemCodes.Snes;
-		result.Region = RegionType.Ntsc;
+		result.Region = RegionType.NTSC;
 		result.WarningList.Add(ParseWarnings.SystemIdInferred);
 		result.WarningList.Add(ParseWarnings.RegionInferred);
 	}

--- a/TASVideos.Parsers/Parsers/M64.cs
+++ b/TASVideos.Parsers/Parsers/M64.cs
@@ -7,7 +7,7 @@ internal class M64 : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.N64
 		};
 
@@ -25,7 +25,7 @@ internal class M64 : Parser, IParser
 		var fps = br.ReadByte(); // Vertical interrupts per second
 		if (fps == 50)
 		{
-			result.Region = RegionType.Pal;
+			result.Region = RegionType.PAL;
 		}
 
 		br.ReadByte(); // Number of controllers

--- a/TASVideos.Parsers/Parsers/Mar.cs
+++ b/TASVideos.Parsers/Parsers/Mar.cs
@@ -7,7 +7,7 @@ internal class Mar : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.Arcade
 		};
 

--- a/TASVideos.Parsers/Parsers/Omr.cs
+++ b/TASVideos.Parsers/Parsers/Omr.cs
@@ -11,7 +11,7 @@ internal class Omr : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.Msx
 		};
 
@@ -34,7 +34,7 @@ internal class Omr : Parser, IParser
 
 		if (isPal)
 		{
-			result.Region = RegionType.Pal;
+			result.Region = RegionType.PAL;
 		}
 
 		var lengthTimestamp = long.Parse(replay.XPathEvaluateList("//events/item")
@@ -46,7 +46,7 @@ internal class Omr : Parser, IParser
 
 		var seconds = ConvertTimestamp(lengthTimestamp);
 
-		result.Frames = (int)Math.Round(seconds * (result.Region == RegionType.Pal ? 50.1589758045661 : 59.9227510135505));
+		result.Frames = (int)Math.Round(seconds * (result.Region == RegionType.PAL ? 50.1589758045661 : 59.9227510135505));
 
 		var version = replay.XPathEvaluateList("//snapshots/item").FirstAttributeValue("version");
 

--- a/TASVideos.Parsers/Parsers/P2m2.cs
+++ b/TASVideos.Parsers/Parsers/P2m2.cs
@@ -7,7 +7,7 @@ internal class P2m2 : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.Ps2
 		};
 

--- a/TASVideos.Parsers/Parsers/ThreeCt.cs
+++ b/TASVideos.Parsers/Parsers/ThreeCt.cs
@@ -7,7 +7,7 @@ internal class ThreeCt : Parser, IParser
 	{
 		var result = new SuccessResult(FileExtension)
 		{
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			SystemCode = SystemCodes.Nes,
 			FrameRateOverride = 5369318.18181818
 		};

--- a/TASVideos.Parsers/Result/Enums.cs
+++ b/TASVideos.Parsers/Result/Enums.cs
@@ -14,12 +14,12 @@ public enum RegionType
 	/// <summary>
 	/// Indicates that the region is the NTSC standard
 	/// </summary>
-	Ntsc,
+	NTSC,
 
 	/// <summary>
 	/// Indicates that the region is the PAL standard
 	/// </summary>
-	Pal,
+	PAL,
 
 	/// <summary>
 	/// Indicates the system is not TV based

--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -231,7 +231,7 @@
 			<td>@version.Version</td>
 			<td>@version.SystemCode</td>
 			<td style="overflow-wrap: anywhere">
-				<small condition="!string.IsNullOrWhiteSpace(version.Sha1)">SHA1: @version.Sha1</small><br />
+				<small condition="!string.IsNullOrWhiteSpace(version.Sha1)">SHA-1: @version.Sha1</small><br />
 				<small condition="!string.IsNullOrWhiteSpace(version.Md5)">MD5: @version.Md5</small>
 			</td>
 		</tr>

--- a/TASVideos/Pages/Games/Versions/Edit.cshtml
+++ b/TASVideos/Pages/Games/Versions/Edit.cshtml
@@ -26,12 +26,12 @@
 				<span asp-validation-for="Version.Name"></span>
 			</fieldset>
 			<fieldset>
-				<label asp-for="Version.Sha1"></label>
+				<label asp-for="Version.Sha1">SHA-1</label>
 				<input asp-for="Version.Sha1" data-id="sha1" autocomplete="off" spellcheck="false" />
 				<span asp-validation-for="Version.Sha1"></span>
 			</fieldset>
 			<fieldset>
-				<label asp-for="Version.Md5"></label>
+				<label asp-for="Version.Md5">MD5</label>
 				<input asp-for="Version.Md5" data-id="md5" autocomplete="off" spellcheck="false" />
 				<span asp-validation-for="Version.Md5"></span>
 			</fieldset>

--- a/TASVideos/Pages/Games/Versions/List.cshtml
+++ b/TASVideos/Pages/Games/Versions/List.cshtml
@@ -31,7 +31,7 @@
 			<td>@version.Version</td>
 			<td>@version.Region</td>
 			<td style="overflow-wrap: anywhere">
-				<small condition="!string.IsNullOrEmpty(version.Sha1)">SHA1: @version.Sha1</small><br />
+				<small condition="!string.IsNullOrEmpty(version.Sha1)">SHA-1: @version.Sha1</small><br />
 				<small condition="!string.IsNullOrEmpty(version.Md5)">MD5: @version.Md5</small>
 			</td>
 			<td>@version.System</td>

--- a/TASVideos/Pages/Games/Versions/View.cshtml
+++ b/TASVideos/Pages/Games/Versions/View.cshtml
@@ -40,11 +40,11 @@
 			</column>
 			<column md="6">
 				<div class="info-entry">
-					<label asp-for="Version.Sha1"></label>
+					<label asp-for="Version.Sha1">SHA-1</label>
 					<label>@Model.Version.Sha1</label>
 				</div>
 				<div class="info-entry">
-					<label asp-for="Version.Md5"></label>
+					<label asp-for="Version.Md5">MD5</label>
 					<label>@Model.Version.Md5</label>
 				</div>
 				<div class="info-entry">

--- a/TASVideos/Pages/Systems/CreateFramerate.cshtml
+++ b/TASVideos/Pages/Systems/CreateFramerate.cshtml
@@ -14,9 +14,9 @@
 				<span asp-validation-for="FrameRate"></span>
 			</fieldset>
 			<fieldset>
-				<label asp-for="RegionCode"></label>
-				<input asp-for="RegionCode" />
-				<span asp-validation-for="RegionCode"></span>
+				<label asp-for="Region"></label>
+				<select asp-for="Region" asp-items="Model.RegionTypes"></select>
+				<span asp-validation-for="Region"></span>
 			</fieldset>
 			<fieldset>
 				<label>Indicates that the framerate is provisional for now and not intended to be an accurate value</label>

--- a/TASVideos/Pages/Systems/CreateFramerate.cshtml.cs
+++ b/TASVideos/Pages/Systems/CreateFramerate.cshtml.cs
@@ -25,9 +25,6 @@ public class CreateFramerateModel(IGameSystemService systemService, ApplicationD
 	[BindProperty]
 	public bool Preliminary { get; set; }
 
-	[BindProperty]
-	public bool Obsolete { get; set; }
-
 	public List<SelectListItem> RegionTypes => RegionTypeList;
 
 	public async Task<IActionResult> OnGet()

--- a/TASVideos/Pages/Systems/CreateFramerate.cshtml.cs
+++ b/TASVideos/Pages/Systems/CreateFramerate.cshtml.cs
@@ -1,10 +1,15 @@
 using TASVideos.Data.Entity.Game;
+using TASVideos.MovieParsers.Result;
 
 namespace TASVideos.Pages.Systems;
 
 [RequirePermission(PermissionTo.GameSystemMaintenance)]
 public class CreateFramerateModel(IGameSystemService systemService, ApplicationDbContext db) : BasePageModel
 {
+	protected static readonly List<SelectListItem> RegionTypeList = Enum
+		.GetValues<RegionType>()
+		.ToDropDown();
+
 	[FromRoute]
 	public int SystemId { get; set; }
 
@@ -15,14 +20,15 @@ public class CreateFramerateModel(IGameSystemService systemService, ApplicationD
 	public double FrameRate { get; set; }
 
 	[BindProperty]
-	[StringLength(8)]
-	public string RegionCode { get; set; } = "";
+	public RegionType Region { get; set; }
 
 	[BindProperty]
 	public bool Preliminary { get; set; }
 
 	[BindProperty]
 	public bool Obsolete { get; set; }
+
+	public List<SelectListItem> RegionTypes => RegionTypeList;
 
 	public async Task<IActionResult> OnGet()
 	{
@@ -54,7 +60,7 @@ public class CreateFramerateModel(IGameSystemService systemService, ApplicationD
 		{
 			GameSystemId = SystemId,
 			FrameRate = FrameRate,
-			RegionCode = RegionCode,
+			RegionCode = Region.ToString(),
 			Preliminary = Preliminary,
 			Obsolete = false
 		});

--- a/TASVideos/Pages/Systems/EditFramerate.cshtml
+++ b/TASVideos/Pages/Systems/EditFramerate.cshtml
@@ -45,7 +45,7 @@
 			</fieldset>
 			<fieldset>
 				<label asp-for="FrameRate.RegionCode"></label>
-				<input asp-for="FrameRate.RegionCode" />
+				<select asp-for="FrameRate.RegionCode" asp-items="Model.RegionTypes"></select>
 				<span asp-validation-for="FrameRate.RegionCode"></span>
 			</fieldset>
 			<fieldset>

--- a/TASVideos/Pages/Systems/EditFramerate.cshtml.cs
+++ b/TASVideos/Pages/Systems/EditFramerate.cshtml.cs
@@ -25,25 +25,35 @@ public class EditFramerateModel(ApplicationDbContext db, IGameSystemService game
 
 	public async Task<IActionResult> OnGet()
 	{
-		var frameRate = await db.GameSystemFrameRates
+		var dbValues = await db.GameSystemFrameRates
 			.Where(sf => sf.Id == Id)
-			.Select(sf => new FrameRateEdit
+			.Select(sf => new
 			{
-				SystemId = sf.System!.Id,
-				SystemCode = sf.System!.Code,
-				FrameRate = sf.FrameRate,
-				RegionCode = sf.RegionCode,
-				Preliminary = sf.Preliminary,
-				Obsolete = sf.Obsolete
+				sf.System!.Id,
+				sf.System!.Code,
+				sf.FrameRate,
+				sf.RegionCode,
+				sf.Preliminary,
+				sf.Obsolete
 			})
 			.SingleOrDefaultAsync();
 
-		if (frameRate is null)
+		if (dbValues is null)
 		{
 			return NotFound();
 		}
 
-		FrameRate = frameRate;
+		var parseResult = Enum.TryParse<RegionType>(dbValues.RegionCode, out var regionCode);
+
+		FrameRate = new FrameRateEdit
+		{
+			SystemId = dbValues.Id,
+			SystemCode = dbValues.Code,
+			FrameRate = dbValues.FrameRate,
+			RegionCode =  parseResult ? regionCode : RegionType.Unknown,
+			Preliminary = dbValues.Preliminary,
+			Obsolete = dbValues.Obsolete
+		};
 
 		await PopulateUsages();
 		return Page();
@@ -66,7 +76,7 @@ public class EditFramerateModel(ApplicationDbContext db, IGameSystemService game
 		}
 
 		frameRate.FrameRate = FrameRate.FrameRate;
-		frameRate.RegionCode = FrameRate.RegionCode;
+		frameRate.RegionCode = FrameRate.RegionCode.ToString();
 		frameRate.Preliminary = FrameRate.Preliminary;
 		frameRate.Obsolete = FrameRate.Obsolete;
 
@@ -121,8 +131,7 @@ public class EditFramerateModel(ApplicationDbContext db, IGameSystemService game
 		public string SystemCode { get; init; } = "";
 		public double FrameRate { get; init; }
 
-		[StringLength(8)]
-		public string RegionCode { get; init; } = "";
+		public RegionType RegionCode { get; init; }
 		public bool Preliminary { get; init; }
 
 		public bool Obsolete { get; init; }

--- a/TASVideos/Pages/Systems/EditFramerate.cshtml.cs
+++ b/TASVideos/Pages/Systems/EditFramerate.cshtml.cs
@@ -1,10 +1,15 @@
 using System.Globalization;
+using TASVideos.MovieParsers.Result;
 
 namespace TASVideos.Pages.Systems;
 
 [RequirePermission(PermissionTo.GameSystemMaintenance)]
 public class EditFramerateModel(ApplicationDbContext db, IGameSystemService gameSystemService) : BasePageModel
 {
+	protected static readonly List<SelectListItem> RegionTypeList = Enum
+		.GetValues<RegionType>()
+		.ToDropDown();
+
 	[FromRoute]
 	public int Id { get; set; }
 
@@ -15,6 +20,8 @@ public class EditFramerateModel(ApplicationDbContext db, IGameSystemService game
 	public List<UsageEntry> SubmissionEntries = [];
 
 	public bool InUse => PublicationEntries.Any() || SubmissionEntries.Any();
+
+	public List<SelectListItem> RegionTypes => RegionTypeList;
 
 	public async Task<IActionResult> OnGet()
 	{

--- a/TASVideos/Pages/Systems/EditFramerate.cshtml.cs
+++ b/TASVideos/Pages/Systems/EditFramerate.cshtml.cs
@@ -50,7 +50,7 @@ public class EditFramerateModel(ApplicationDbContext db, IGameSystemService game
 			SystemId = dbValues.Id,
 			SystemCode = dbValues.Code,
 			FrameRate = dbValues.FrameRate,
-			RegionCode =  parseResult ? regionCode : RegionType.Unknown,
+			RegionCode = parseResult ? regionCode : RegionType.Unknown,
 			Preliminary = dbValues.Preliminary,
 			Obsolete = dbValues.Obsolete
 		};

--- a/TASVideos/WikiModules/NoGameVersion.cshtml
+++ b/TASVideos/WikiModules/NoGameVersion.cshtml
@@ -66,7 +66,7 @@
 		</card-header>
 		<card-body>
 			<p>Game: <a asp-page="/Games/Index" asp-route-id="@version.GameId">@version.GameName</a></p>
-			<p>SHA1: @version.Sha1</p>
+			<p>SHA-1: @version.Sha1</p>
 			<p>MD5: @version.Md5</p>
 			Publications:
 			<ul>

--- a/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
+++ b/tests/TASVideos.Core.Tests/Services/QueueServiceTests.cs
@@ -494,7 +494,7 @@ public class QueueServiceTests : TestDbBase
 	{
 		const string system = "NES";
 		const double frameRate = 60.0;
-		const RegionType region = RegionType.Ntsc;
+		const RegionType region = RegionType.NTSC;
 		const MovieStartType startType = MovieStartType.Savestate;
 		const int frames = 42069;
 		const int rerecordCount = 420;
@@ -537,7 +537,7 @@ public class QueueServiceTests : TestDbBase
 	{
 		const string system = "NES";
 		const double frameRateOverride = 61.0;
-		const RegionType region = RegionType.Ntsc;
+		const RegionType region = RegionType.NTSC;
 		var entry = _db.GameSystems.Add(new GameSystem { Code = system });
 		await _db.SaveChangesAsync();
 		var parseResult = new TestParseResult
@@ -807,7 +807,7 @@ public class QueueServiceTests : TestDbBase
 		{
 			Success = true,
 			SystemCode = "NES",
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			Hashes = new Dictionary<HashType, string>
 			{
 				[HashType.Sha1] = "abc123def456"
@@ -840,7 +840,7 @@ public class QueueServiceTests : TestDbBase
 		{
 			Success = true,
 			SystemCode = "NES",
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			FrameRateOverride = customFrameRate
 		};
 
@@ -880,7 +880,7 @@ public class QueueServiceTests : TestDbBase
 		{
 			Success = true,
 			SystemCode = "NES",
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			Annotations = annotations,
 			WarningsList = [ParseWarnings.MissingRerecordCount, ParseWarnings.SystemIdInferred]
 		};
@@ -964,7 +964,7 @@ public class QueueServiceTests : TestDbBase
 		{
 			Success = true,
 			SystemCode = systemCode,
-			Region = RegionType.Ntsc,
+			Region = RegionType.NTSC,
 			StartType = MovieStartType.PowerOn,
 			Frames = 1000,
 			RerecordCount = 50,

--- a/tests/TASVideos.MovieParsers.Tests/Bk2ParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/Bk2ParserTests.cs
@@ -68,8 +68,8 @@ public class Bk2ParserTests : BaseParserTests
 	}
 
 	[TestMethod]
-	[DataRow("Pal1.bk2", RegionType.Pal)]
-	[DataRow("0Frames.bk2", RegionType.Ntsc, DisplayName = "Missing flag defaults to Ntsc")]
+	[DataRow("Pal1.bk2", RegionType.PAL)]
+	[DataRow("0Frames.bk2", RegionType.NTSC, DisplayName = "Missing flag defaults to Ntsc")]
 	public async Task PalFlag_True(string fileName, RegionType expected)
 	{
 		var result = await _bk2Parser.Parse(Embedded(fileName, out var length), length);

--- a/tests/TASVideos.MovieParsers.Tests/CtmTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/CtmTests.cs
@@ -49,7 +49,7 @@ public class CtmTests : BaseParserTests
 		var result = await _ctmParser.Parse(Embedded("2frames.ctm", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/Fm2ParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/Fm2ParserTests.cs
@@ -13,7 +13,7 @@ public class Fm2ParserTests : BaseParserTests
 		var result = await _fm2Parser.Parse(Embedded("ntsc.fm2", out var length), length);
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
 		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -26,7 +26,7 @@ public class Fm2ParserTests : BaseParserTests
 		var result = await _fm2Parser.Parse(Embedded("pal.fm2", out var length), length);
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
-		Assert.AreEqual(RegionType.Pal, result.Region);
+		Assert.AreEqual(RegionType.PAL, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
 		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -39,7 +39,7 @@ public class Fm2ParserTests : BaseParserTests
 		var result = await _fm2Parser.Parse(Embedded("fds.fm2", out var length), length);
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
 		Assert.AreEqual(SystemCodes.Fds, result.SystemCode, "System should be FDS");
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -52,7 +52,7 @@ public class Fm2ParserTests : BaseParserTests
 		var result = await _fm2Parser.Parse(Embedded("savestate.fm2", out var length), length);
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
 		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);

--- a/tests/TASVideos.MovieParsers.Tests/Fm3ParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/Fm3ParserTests.cs
@@ -13,7 +13,7 @@ public class Fm3ParserTests : BaseParserTests
 		var result = await _fm3Parser.Parse(Embedded("ntsc.fm3", out var length), length);
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
 		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -26,7 +26,7 @@ public class Fm3ParserTests : BaseParserTests
 		var result = await _fm3Parser.Parse(Embedded("pal.fm3", out var length), length);
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
-		Assert.AreEqual(RegionType.Pal, result.Region);
+		Assert.AreEqual(RegionType.PAL, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
 		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -39,7 +39,7 @@ public class Fm3ParserTests : BaseParserTests
 		var result = await _fm3Parser.Parse(Embedded("fds.fm3", out var length), length);
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
 		Assert.AreEqual(SystemCodes.Fds, result.SystemCode, "System should be FDS");
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
@@ -52,7 +52,7 @@ public class Fm3ParserTests : BaseParserTests
 		var result = await _fm3Parser.Parse(Embedded("savestate.fm3", out var length), length);
 		Assert.IsTrue(result.Success, "Result is successful");
 		Assert.AreEqual(2, result.Frames, "Frame count should be 2");
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 		Assert.AreEqual(21, result.RerecordCount);
 		Assert.AreEqual(SystemCodes.Nes, result.SystemCode, "System should be NES");
 		Assert.AreEqual(MovieStartType.Savestate, result.StartType);

--- a/tests/TASVideos.MovieParsers.Tests/GmvTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/GmvTests.cs
@@ -49,7 +49,7 @@ public class GmvTests : BaseParserTests
 		var result = await _gmvParser.Parse(Embedded("2frames.gmv", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 	}
 
 	[TestMethod]
@@ -58,7 +58,7 @@ public class GmvTests : BaseParserTests
 		var result = await _gmvParser.Parse(Embedded("pal.gmv", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Pal, result.Region);
+		Assert.AreEqual(RegionType.PAL, result.Region);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/LmpTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/LmpTests.cs
@@ -36,6 +36,7 @@ public class LmpTests : BaseParserTests
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Pc, result.SystemCode);
+		Assert.AreEqual(RegionType.World, result.Region);
 		Assert.AreEqual(7071, result.Frames);
 		Assert.AreEqual(0, result.RerecordCount, "Lmp does not track rerecords");
 		Assert.IsNull(result.Annotations);

--- a/tests/TASVideos.MovieParsers.Tests/LsmvTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/LsmvTests.cs
@@ -95,19 +95,19 @@ public class LsmvTests : BaseParserTests
 		var result = await _lsmvParser.Parse(Embedded("gametype-empty.lsmv", out var length), length);
 		Assert.IsTrue(result.Success);
 		Assert.AreEqual(SystemCodes.Snes, result.SystemCode);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 		Assert.AreEqual(2, result.Warnings.Count());
 		AssertNoErrors(result);
 	}
 
 	[TestMethod]
-	[DataRow("gametype-snesntsc.lsmv", SystemCodes.Snes, RegionType.Ntsc)]
-	[DataRow("gametype-snespal.lsmv", SystemCodes.Snes, RegionType.Pal)]
-	[DataRow("gametype-bsx.lsmv", SystemCodes.Snes, RegionType.Ntsc)]
-	[DataRow("gametype-bsxslotted.lsmv", SystemCodes.Snes, RegionType.Ntsc)]
-	[DataRow("gametype-sufamiturbo.lsmv", SystemCodes.Snes, RegionType.Ntsc)]
-	[DataRow("gametype-sgb_ntsc.lsmv", SystemCodes.Sgb, RegionType.Ntsc)]
-	[DataRow("gametype-sgb_pal.lsmv", SystemCodes.Sgb, RegionType.Pal)]
+	[DataRow("gametype-snesntsc.lsmv", SystemCodes.Snes, RegionType.NTSC)]
+	[DataRow("gametype-snespal.lsmv", SystemCodes.Snes, RegionType.PAL)]
+	[DataRow("gametype-bsx.lsmv", SystemCodes.Snes, RegionType.NTSC)]
+	[DataRow("gametype-bsxslotted.lsmv", SystemCodes.Snes, RegionType.NTSC)]
+	[DataRow("gametype-sufamiturbo.lsmv", SystemCodes.Snes, RegionType.NTSC)]
+	[DataRow("gametype-sgb_ntsc.lsmv", SystemCodes.Sgb, RegionType.NTSC)]
+	[DataRow("gametype-sgb_pal.lsmv", SystemCodes.Sgb, RegionType.PAL)]
 	[DataRow("gametype-gdmg.lsmv", SystemCodes.GameBoy, RegionType.World)]
 	[DataRow("gametype-ggbc.lsmv", SystemCodes.Gbc, RegionType.World)]
 	[DataRow("gametype-ggbca.lsmv", SystemCodes.Gbc, RegionType.World)]

--- a/tests/TASVideos.MovieParsers.Tests/M64Tests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/M64Tests.cs
@@ -49,7 +49,7 @@ public class M64Tests : BaseParserTests
 		var result = await _m64Parser.Parse(Embedded("2frames.m64", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 	}
 
 	[TestMethod]
@@ -58,7 +58,7 @@ public class M64Tests : BaseParserTests
 		var result = await _m64Parser.Parse(Embedded("pal.m64", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Pal, result.Region);
+		Assert.AreEqual(RegionType.PAL, result.Region);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/MarTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/MarTests.cs
@@ -40,7 +40,7 @@ public class MarTests : BaseParserTests
 		var result = await _marParser.Parse(Embedded("2frames.mar", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/OmrTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/OmrTests.cs
@@ -104,7 +104,7 @@ public class OmrTests : BaseParserTests
 		var result = await _omrParser.Parse(Embedded("2seconds.omr", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 	}
 
 	[TestMethod]
@@ -113,7 +113,7 @@ public class OmrTests : BaseParserTests
 		var result = await _omrParser.Parse(Embedded("pal.omr", out var length), length);
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
-		Assert.AreEqual(RegionType.Pal, result.Region);
+		Assert.AreEqual(RegionType.PAL, result.Region);
 	}
 
 	[TestMethod]

--- a/tests/TASVideos.MovieParsers.Tests/ThreeCtParserTests.cs
+++ b/tests/TASVideos.MovieParsers.Tests/ThreeCtParserTests.cs
@@ -14,7 +14,7 @@ public class ThreeCtParserTests : BaseParserTests
 		Assert.IsTrue(result.Success);
 		AssertNoWarningsOrErrors(result);
 		Assert.AreEqual(SystemCodes.Nes, result.SystemCode);
-		Assert.AreEqual(RegionType.Ntsc, result.Region);
+		Assert.AreEqual(RegionType.NTSC, result.Region);
 		Assert.AreEqual(0, result.RerecordCount);
 		Assert.AreEqual(MovieStartType.PowerOn, result.StartType);
 		Assert.AreEqual("3ct", result.FileExtension);


### PR DESCRIPTION
see #1539

- when override is used during movie parsing, don't uppercase region code (because `World` should not be)
- when user creates framerate, use region enum dropdown instead of arbitrary string

TODO: figure out editing a framerate (should we accept the string and then try to match it to enum values, or is it better to change the field itself to enum globally?)

unrelated tiny tweak for GUI: fix SHA-1 and MD5 displayed names