### PR TITLE
Layout improvements to Game Versions table

### DIFF
--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -1,5 +1,4 @@
 @page "{id}"
-@using TASVideos.Data.Entity.Game
 @model IndexModel
 @{
 	ViewData.SetTitle($"{Model.Game.DisplayName}");
@@ -21,7 +20,7 @@
 		ViewData.SetNavigation(id, "/{0}G");
 	}
 
-	SortedSet<string> platforms = new(Model.Game.Versions.Select(v => v.SystemCode!));
+	SortedSet<string> platforms = new(Model.Game.Versions.Select(v => v.System));
 }
 
 <card class="mb-3">
@@ -221,19 +220,6 @@
 	<table-head columns="Type,Name,Title Override,Region,Version,Platform,Hashes"></table-head>
 	@foreach (var version in Model.Game.Versions.OrderBy(v => v.Name))
 	{
-		<tr>
-			<td>
-				<span class="text-nowrap"><i condition="@version.Type == VersionTypes.Unknown" class="fa fa-circle-question"></i> @version.Type</span>
-			</td>
-			<td>@version.Name</td>
-			<td>@version.TitleOverride</td>
-			<td>@version.Region</td>
-			<td>@version.Version</td>
-			<td>@version.SystemCode</td>
-			<td style="overflow-wrap: anywhere">
-				<small condition="!string.IsNullOrWhiteSpace(version.Sha1)">SHA-1: @version.Sha1</small><br />
-				<small condition="!string.IsNullOrWhiteSpace(version.Md5)">MD5: @version.Md5</small>
-			</td>
-		</tr>
+		<partial name="_GameVersionTableRow" model="version" />
 	}
 </standard-table>

--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -218,7 +218,7 @@
 </alert>
 <standard-table condition="Model.Game.Versions.Any()">
 	<table-head columns="Type,Name,Title Override,Region,Version,Platform,Hashes"></table-head>
-	@foreach (var version in Model.Game.Versions.OrderBy(v => v.Name))
+	@foreach (var version in Model.Game.Versions)
 	{
 		<partial name="_GameVersionTableRow" model="version" />
 	}

--- a/TASVideos/Pages/Games/Index.cshtml.cs
+++ b/TASVideos/Pages/Games/Index.cshtml.cs
@@ -2,6 +2,8 @@ using TASVideos.Data.Entity.Forum;
 using TASVideos.Data.Entity.Game;
 using TASVideos.WikiModules;
 
+using static TASVideos.Pages.Games.Versions.ListModel;
+
 namespace TASVideos.Pages.Games;
 
 [AllowAnonymous]
@@ -29,15 +31,17 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 			ScreenshotUrl = g.ScreenshotUrl,
 			GameResourcesPage = g.GameResourcesPage,
 			Genres = g.GameGenres.Select(gg => gg.Genre!.DisplayName).ToList(),
-			Versions = g.GameVersions.Select(gv => new GameDisplay.GameVersion(
-				gv.Type,
+			Versions = g.GameVersions.Select(gv => new VersionEntry(
+				gv.Id,
+				gv.Name,
 				gv.Md5,
 				gv.Sha1,
-				gv.Name,
-				gv.Region,
 				gv.Version,
+				gv.Region,
+				gv.Type,
 				gv.System!.Code,
-				gv.TitleOverride)).ToList(),
+				gv.TitleOverride,
+				gv.SourceDb)).ToList(),
 			GameGroups = g.GameGroups.Select(gg => new GameDisplay.GameGroup(gg.GameGroupId, gg.GameGroup!.Name)).ToList(),
 			PublicationCount = g.Publications.Count(p => p.ObsoletedById == null),
 			ObsoletePublicationCount = g.Publications.Count(p => p.ObsoletedById != null),
@@ -159,23 +163,13 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 		public string? ScreenshotUrl { get; init; }
 		public string? GameResourcesPage { get; init; }
 		public List<string> Genres { get; init; } = [];
-		public List<GameVersion> Versions { get; init; } = [];
+		public List<VersionEntry> Versions { get; init; } = [];
 		public List<GameGroup> GameGroups { get; init; } = [];
 		public List<PlaygroundSubmission> PlaygroundSubmissions { get; init; } = [];
 		public int PublicationCount { get; init; }
 		public int ObsoletePublicationCount { get; init; }
 		public int SubmissionCount { get; init; }
 		public int UserFilesCount { get; init; }
-
-		public record GameVersion(
-			VersionTypes Type,
-			string? Md5,
-			string? Sha1,
-			string Name,
-			string? Region,
-			string? Version,
-			string? SystemCode,
-			string? TitleOverride);
 
 		public record GameGroup(int Id, string Name);
 	}

--- a/TASVideos/Pages/Games/Index.cshtml.cs
+++ b/TASVideos/Pages/Games/Index.cshtml.cs
@@ -31,7 +31,10 @@ public class IndexModel(ApplicationDbContext db) : BasePageModel
 			ScreenshotUrl = g.ScreenshotUrl,
 			GameResourcesPage = g.GameResourcesPage,
 			Genres = g.GameGenres.Select(gg => gg.Genre!.DisplayName).ToList(),
-			Versions = g.GameVersions.Select(gv => new VersionEntry(
+			Versions = g.GameVersions.OrderBy(v => v.Type)
+				.ThenBy(v => v.System!.Code)
+				.ThenBy(v => v.Region)
+				.Select(gv => new VersionEntry(
 				gv.Id,
 				gv.Name,
 				gv.Md5,

--- a/TASVideos/Pages/Games/Versions/List.cshtml
+++ b/TASVideos/Pages/Games/Versions/List.cshtml
@@ -1,8 +1,12 @@
 @page "/Games/{gameId}/Versions/List"
-@using TASVideos.Data.Entity.Game
 @model ListModel
 @{
 	ViewData.SetTitle($"Versions for {Model.GameDisplayName}");
+	ViewDataDictionary viewDataForRowHelper = new(ViewData)
+	{
+		["GameID"] = Model.GameId,
+		["ShowSourceDB"] = true, // could use the presence of GameID for this too
+	};
 }
 
 @section PageTitle {
@@ -13,41 +17,10 @@
 	<add-link asp-page="Edit" permission="CatalogMovies" asp-route-gameId="@Model.GameId"></add-link>
 </top-button-bar>
 <standard-table>
-	<table-head columns="Type,Name,Title Override,Version,Region,Hashes,System,"></table-head>
+	<table-head columns="Type,Name,Title Override,Region,Version,Platform,Hashes,"></table-head>
 	@foreach (var version in Model.Versions.OrderBy(v => v.Name))
 	{
-		<tr>
-			<td>
-				<span class="text-nowrap"><i condition="@version.Type == VersionTypes.Unknown" class="fa fa-circle-question"></i> @version.Type</span>
-			</td>
-			<td>
-				@version.Name
-				@if (!string.IsNullOrWhiteSpace(version.SourceDb))
-				{
-					<br /><span>SourceDB: @version.SourceDb</span>
-				}
-			</td>
-			<td>@version.TitleOverride</td>
-			<td>@version.Version</td>
-			<td>@version.Region</td>
-			<td style="overflow-wrap: anywhere">
-				<small condition="!string.IsNullOrEmpty(version.Sha1)">SHA-1: @version.Sha1</small><br />
-				<small condition="!string.IsNullOrEmpty(version.Md5)">MD5: @version.Md5</small>
-			</td>
-			<td>@version.System</td>
-			<td-action-column>
-				<div class="d-flex flex-wrap gap-1">
-					<a
-						class="btn btn-secondary btn-sm"
-						asp-page="/Games/Versions/View"
-						asp-route-gameId="@Model.GameId"
-						asp-route-id="@version.Id">
-						<i class="fa fa-eye"></i> View
-					</a>
-					<edit-link class="btn-sm" asp-page="Edit" permission="CatalogMovies" asp-route-id="@version.Id" asp-route-gameId="@Model.GameId"></edit-link>
-				</div>
-			</td-action-column>
-		</tr>
+		<partial name="_GameVersionTableRow" model="version" view-data="viewDataForRowHelper" />
 	}
 </standard-table>
 

--- a/TASVideos/Pages/Games/Versions/List.cshtml
+++ b/TASVideos/Pages/Games/Versions/List.cshtml
@@ -18,7 +18,7 @@
 </top-button-bar>
 <standard-table>
 	<table-head columns="Type,Name,Title Override,Region,Version,Platform,Hashes,"></table-head>
-	@foreach (var version in Model.Versions.OrderBy(v => v.Name))
+	@foreach (var version in Model.Versions)
 	{
 		<partial name="_GameVersionTableRow" model="version" view-data="viewDataForRowHelper" />
 	}

--- a/TASVideos/Pages/Games/Versions/List.cshtml.cs
+++ b/TASVideos/Pages/Games/Versions/List.cshtml.cs
@@ -26,6 +26,9 @@ public class ListModel(ApplicationDbContext db) : BasePageModel
 		GameDisplayName = displayName;
 		Versions = await db.GameVersions
 			.Where(v => v.GameId == GameId)
+			.OrderBy(v => v.Type)
+			.ThenBy(v => v.System!.Code)
+			.ThenBy(v => v.Region)
 			.Select(v => new VersionEntry(
 				v.Id,
 				v.Name,

--- a/TASVideos/Pages/Shared/_GameVersionTableRow.cshtml
+++ b/TASVideos/Pages/Shared/_GameVersionTableRow.cshtml
@@ -1,0 +1,35 @@
+@using TASVideos.Data.Entity.Game
+@model TASVideos.Pages.Games.Versions.ListModel.VersionEntry
+
+<tr>
+	<td>
+		<span class="text-nowrap"><i condition="@Model.Type == VersionTypes.Unknown" class="fa fa-circle-question"></i> @Model.Type</span>
+	</td>
+	<td>
+		@Model.Name
+		@if (!string.IsNullOrWhiteSpace(Model.SourceDb) && ViewData.ContainsKey("ShowSourceDB"))
+		{
+			<br /><span>SourceDB: @Model.SourceDb</span>
+		}
+	</td>
+	<td>@Model.TitleOverride</td>
+	<td>@Model.Region</td>
+	<td>@Model.Version</td>
+	<td>@Model.System</td>
+	<td style="overflow-wrap: anywhere">
+		<small condition="!string.IsNullOrEmpty(Model.Sha1)">SHA-1: @Model.Sha1</small><br />
+		<small condition="!string.IsNullOrEmpty(Model.Md5)">MD5: @Model.Md5</small>
+	</td>
+	<td-action-column condition="@ViewData.ContainsKey("GameID")">
+		<div class="d-flex flex-wrap gap-1">
+			<a
+				class="btn btn-secondary btn-sm"
+				asp-page="/Games/Versions/View"
+				asp-route-gameId="@ViewData["GameID"]"
+				asp-route-id="@Model.Id">
+				<i class="fa fa-eye"></i> View
+			</a>
+			<edit-link class="btn-sm" asp-page="Edit" permission="CatalogMovies" asp-route-id="@Model.Id" asp-route-gameId="@ViewData["GameID"]"></edit-link>
+		</div>
+	</td-action-column>
+</tr>

--- a/TASVideos/Pages/Shared/_GameVersionTableRow.cshtml
+++ b/TASVideos/Pages/Shared/_GameVersionTableRow.cshtml
@@ -1,3 +1,4 @@
+@using System.Globalization
 @using TASVideos.Data.Entity.Game
 @model TASVideos.Pages.Games.Versions.ListModel.VersionEntry
 
@@ -16,9 +17,20 @@
 	<td>@Model.Region</td>
 	<td>@Model.Version</td>
 	<td>@Model.System</td>
-	<td style="overflow-wrap: anywhere">
-		<small condition="!string.IsNullOrEmpty(Model.Sha1)">SHA-1: @Model.Sha1</small><br />
-		<small condition="!string.IsNullOrEmpty(Model.Md5)">MD5: @Model.Md5</small>
+	<td>
+		@{
+			byte Sample(string digest, int from)
+				=> byte.TryParse(digest.AsSpan(start: from, length: 2), NumberStyles.AllowHexSpecifier, null, out var b) ? b : default;
+			// re: wbr, we could simply insert a U+200B ZWSP in the middle of the string, but then it would be there when copied
+		}
+		<div condition="!string.IsNullOrEmpty(Model.Sha1)" class="d-flex game-version-checksums">
+			<label for="@Model.Sha1">SHA<span style="user-select: none;">-</span>1:</label>
+			<output id="@Model.Sha1"><samp data-sample-byte="@Sample(Model.Sha1!, 19)">@Model.Sha1![..20]<wbr>@Model.Sha1![20..]</samp></output>
+		</div>
+		<div condition="!string.IsNullOrEmpty(Model.Md5)" class="d-flex game-version-checksums">
+			<label for="@Model.Md5">MD5:</label>
+			<output id="@Model.Md5"><samp data-sample-byte="@Sample(Model.Sha1!, 15)">@Model.Md5![..16]<wbr>@Model.Md5![16..]</samp></output>
+		</div>
 	</td>
 	<td-action-column condition="@ViewData.ContainsKey("GameID")">
 		<div class="d-flex flex-wrap gap-1">

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -720,3 +720,21 @@ top-button-bar {
 		padding-left: 1rem;
 	}
 }
+
+.game-version-checksums {
+	& > label {
+		opacity: 0.6;
+	}
+	& > output > samp {
+		--sample-byte: attr(data-sample-byte type(#{'<number>'})); // workaround for https://github.com/sass/sass/issues/4030
+		color: oklch(30% 40% calc(var(--sample-byte) / 255 * 360));
+		font-size: 95%; // Bootstrap would otherwise have it at 85%
+		padding: 0;
+		text-transform: uppercase;
+	}
+}
+@include color-mode(dark) {
+	.game-version-checksums > output > samp {
+		color: oklch(90% 10% calc(var(--sample-byte) / 255 * 360));
+	}
+}

--- a/tests/TASVideos.RazorPages.Tests/Pages/Games/IndexModelTests.cs
+++ b/tests/TASVideos.RazorPages.Tests/Pages/Games/IndexModelTests.cs
@@ -107,7 +107,7 @@ public class IndexModelTests : TestDbBase
 		Assert.HasCount(1, _model.Game.Versions);
 		var gameVersion = _model.Game.Versions.First();
 		Assert.AreEqual("Version 1.0", gameVersion.Name);
-		Assert.AreEqual("NES", gameVersion.SystemCode);
+		Assert.AreEqual("NES", gameVersion.System);
 		Assert.AreEqual("USA", gameVersion.Region);
 		Assert.AreEqual(VersionTypes.Good, gameVersion.Type);
 		Assert.AreEqual("Custom Title", gameVersion.TitleOverride);


### PR DESCRIPTION
See https://github.com/TASVideos/tasvideos/pull/2350#issuecomment-4915136617 for a screenshot of the latest revision.
~~Before and after~~:
<img width="640" alt="Screenshot from 2026-07-07 04-18-02" src="https://github.com/user-attachments/assets/66736b49-b342-40c3-ac93-228fa158eb08" />
~~Slightly easier to read, but I'm sure it can be improved further. Maybe some colour? I thought of [this xkcd](https://xkcd.com/1286/).~~