### PR TITLE
Limit `float`'d image sizes on wiki pages and game entries

### DIFF
--- a/TASVideos.WikiEngine/MakeBracketed.cs
+++ b/TASVideos.WikiEngine/MakeBracketed.cs
@@ -305,8 +305,6 @@ public static partial class Builtins
 			}
 		}
 
-		classString.Append(" mw-100");
-
 		attrs.Add(Attr("class", classString.ToString()));
 
 		return new Element(charStart, "img", attrs, []) { CharEnd = charEnd };

--- a/TASVideos/Pages/Games/Index.cshtml
+++ b/TASVideos/Pages/Games/Index.cshtml
@@ -32,7 +32,7 @@
 		</div>
 	</card-header>
 	<card-body class="p-1 p-sm-3">
-		<img class="pull-end img-fluid float-sm-end mb-3 mb-sm-0" src="@url" />
+		<img class="pull-end img-fluid embedright mb-3 mb-sm-0" src="@url" />
 		@await Html.RenderWiki(wiki)
 		<row>
 			<column md="6">

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -1,7 +1,6 @@
 /// <reference path="../bootstrap.scss" />
 /// <reference path="colors.scss" />
 /// <reference path="variables.scss" />
-@use "sass:map";
 
 :root {
 	--tasvideos-bg: #{$tasvideos-bg};
@@ -215,34 +214,32 @@ body {
 .embed {
 	border: 0;
 
-	&left {
-		margin-inline-end: 10px;
-		border: 0;
-		clear: inline-start;
-		float: inline-start;
+	&left, &right {
+		display: flex;
+		margin-inline: auto;
+		max-width: 100%;
 	}
 
-	&right {
-		margin-inline-start: 10px;
-		border: 0;
-		clear: inline-end;
-		float: inline-end;
-	}
-}
-@each $size, $width in $container-max-widths {
-	@media (min-width: $width) {
-		// doesn't look good in motion, but this does its job of keeping the accompanying text wide enough to read comfortably
-		.container :is(.embedright, .embedleft) {
-			max-width: calc($width * 2 / 5);
+	@include media-breakpoint-up(sm) {
+		&left {
+			display: block;
+			margin-inline: 0;
+			margin-inline-end: 10px;
+			border: 0;
+			clear: inline-start;
+			float: inline-start;
+			max-width: 50%;
 		}
-	}
-}
-// this is an override for the "extra small" size, which isn't in the map -_-
-@media (max-width: #{map.get($container-max-widths, "sm") - 1px}) {
-	.container .embedright, .container .embedleft {
-		float: unset;
-		margin-inline: 0;
-		width: 100%;
+
+		&right {
+			display: block;
+			margin-inline: 0;
+			margin-inline-start: 10px;
+			border: 0;
+			clear: inline-end;
+			float: inline-end;
+			max-width: 50%;
+		}
 	}
 }
 

--- a/TASVideos/wwwroot/css/partials/_customizations.scss
+++ b/TASVideos/wwwroot/css/partials/_customizations.scss
@@ -1,6 +1,7 @@
 /// <reference path="../bootstrap.scss" />
 /// <reference path="colors.scss" />
 /// <reference path="variables.scss" />
+@use "sass:map";
 
 :root {
 	--tasvideos-bg: #{$tasvideos-bg};
@@ -226,6 +227,22 @@ body {
 		border: 0;
 		clear: inline-end;
 		float: inline-end;
+	}
+}
+@each $size, $width in $container-max-widths {
+	@media (min-width: $width) {
+		// doesn't look good in motion, but this does its job of keeping the accompanying text wide enough to read comfortably
+		.container :is(.embedright, .embedleft) {
+			max-width: calc($width * 2 / 5);
+		}
+	}
+}
+// this is an override for the "extra small" size, which isn't in the map -_-
+@media (max-width: #{map.get($container-max-widths, "sm") - 1px}) {
+	.container .embedright, .container .embedleft {
+		float: unset;
+		margin-inline: 0;
+		width: 100%;
 	}
 }
 


### PR DESCRIPTION
Works with Bootstrap's "Containers" (stepped fixed-width body, which was the crux of the problem).