### PR TITLE
Use a system page as the SSoT for the navbar

### DIFF
--- a/TASVideos.Core/Constants.cs
+++ b/TASVideos.Core/Constants.cs
@@ -59,6 +59,8 @@ public static class SystemWiki
 	public const string MovieLinkInstruction = "System/MovieLinkInstruction";
 	public const string MovieRatingGuidelines = "System/MovieRatingGuidelines";
 	public const string NameChanges = "System/NameChanges";
+	public const string NavbarMain = "System/NavbarMain";
+	public const string NavbarWikiTop = "System/NavbarWikiTop";
 	public const string PlayersHeader = "System/PlayersHeader";
 	public const string RejectionReasonsHeader = "System/RejectionReasonsHeader";
 	public const string SearchTerms = "System/SearchTerms";

--- a/TASVideos.WikiEngine/MakeBracketed.cs
+++ b/TASVideos.WikiEngine/MakeBracketed.cs
@@ -199,9 +199,13 @@ public static partial class Builtins
 	private static IEnumerable<INode> MakeLinkOrImage(int charStart, int charEnd, string text)
 	{
 		var pp = text.Split('|');
-		if (pp.Length >= 2 && IsLink(pp[0]) && IsImage(pp[1]))
+		if (pp.Length >= 2)
 		{
-			return [MakeLink(charStart, charEnd, pp[0], MakeImage(charStart, charEnd, pp, 1, out _))];
+			Console.WriteLine($"===== {pp[0]} -> {IsLink(pp[0])}; {pp[1]} -> {IsImage(pp[1])}");
+			if (IsLink(pp[0]) && IsImage(pp[1]))
+			{
+				return [MakeLink(charStart, charEnd, pp[0], MakeImage(charStart, charEnd, pp, 1, out _))];
+			}
 		}
 
 		if (IsImage(pp[0]))
@@ -271,6 +275,7 @@ public static partial class Builtins
 		{
 			Attr("src", NormalizeImageUrl(pp[index++]))
 		};
+		Console.WriteLine($"===== {attrs[0].Value}");
 		StringBuilder classString = new("embed");
 		for (; index < pp.Length; index++)
 		{

--- a/TASVideos.WikiEngine/PromoteNavItems.cs
+++ b/TASVideos.WikiEngine/PromoteNavItems.cs
@@ -1,0 +1,18 @@
+using TASVideos.WikiEngine.AST;
+
+namespace TASVideos.WikiEngine;
+
+public static partial class Builtins
+{
+	public static INode PromoteNavItem(Element imgElem)
+		=> new Element(
+			imgElem.CharStart,
+			"a",
+			[
+				Attr("class", "dropdown-item"),
+				Attr("href", imgElem.Attributes["src"]),
+			],
+			[
+				new Text(imgElem.CharStart, imgElem.Attributes["title"]),
+			]);
+}

--- a/TASVideos.WikiEngine/Util.cs
+++ b/TASVideos.WikiEngine/Util.cs
@@ -34,7 +34,7 @@ public static class Util
 		}
 	}
 
-	public static async Task RenderHtmlAsync(string content, TextWriter w, IWriterHelper h)
+	public static async Task RenderHtmlAsync(string content, TextWriter w, IWriterHelper h, bool allowMoreStyling = false)
 	{
 		List<INode> results;
 		try
@@ -44,6 +44,18 @@ public static class Util
 		catch (NewParser.SyntaxException e)
 		{
 			results = Builtins.MakeErrorPage(content, e);
+		}
+
+		// could also use this flag to limit, for example, `%%DIV` to system pages, but for now it's just nav
+		if (allowMoreStyling)
+		{
+			const string NavItemIncantation = "/"/*added by `Builtins.NormalizeImageUrl`*/
+				+ "%%NAV_ITEM"/*sigils and magic word*/ + ".svg"/*required to smuggle this through `Builtins.IsImage`*/;
+			NodeUtils.Replace(
+				results,
+				node => node is Element { Children: [Element { Tag: "img" } linkedImg] }
+					&& linkedImg.Attributes.TryGetValue("src", out var src) && src is NavItemIncantation,
+				node => Builtins.PromoteNavItem((Element)((Element)node).Children[0]));
 		}
 
 		var ctx = new WriterContext(h);

--- a/TASVideos/Pages/Shared/_NavBarPartial.cshtml
+++ b/TASVideos/Pages/Shared/_NavBarPartial.cshtml
@@ -1,5 +1,6 @@
 <navbar class="flex-wrap me-2 me-md-0 fw-bold">
 	@* IMPORTANT when adding/removing links to wiki pages: also update the lists at the end of `/TASVideos/TagHelpers/NavbarTagHelpers.cs` *@
+@*
 	<nav-item activate="Home">
 		<a class="nav-link" href="/">Home</a>
 	</nav-item>
@@ -42,13 +43,18 @@
 		<a class="dropdown-item" href="/Helping">How to Help</a>
 		<a class="dropdown-item" href="/SiteHistory">Site History</a>
 	</nav-dropdown>
+	*@
+	@* @await Html.RenderWiki(SystemWiki.NavbarMain) *@
 	<nav-dropdown activate="Wiki"
 				  permissions="new[] { PermissionTo.EditWikiPages, PermissionTo.EditSystemPages, PermissionTo.MoveWikiPages, PermissionTo.DeleteWikiPages }">
+		@*
 		<a class="dropdown-item" href="/SandBox">SandBox</a>
 		<a class="dropdown-item" href="/RecentChanges">Recent Changes</a>
 		<a class="dropdown-item" href="/WikiOrphans">Orphans</a>
 		<a class="dropdown-item" href="/TODO">To Do</a>
 		<a class="dropdown-item" href="/System">System Pages</a>
+		*@
+		@* @await Html.RenderWiki(SystemWiki.NavbarWikiTop) *@
 		<a permission="SeeDeletedWikiPages" asp-page="/Wiki/DeletedPages" class="dropdown-item">Deleted Pages</a>
 		<a permission="EditWikiRedirects" asp-page="/Wiki/Redirects/Index" class="dropdown-item">Redirects</a>
 	</nav-dropdown>

--- a/TASVideos/Pages/Wiki/Preview.cshtml.cs
+++ b/TASVideos/Pages/Wiki/Preview.cshtml.cs
@@ -26,6 +26,7 @@ public class PreviewModel(IWikiPages pages) : BasePageModel
 			}
 
 			PageData = pageData;
+			Console.WriteLine($"===== in PreviewModel: PageData.PageName is {PageData.PageName}");
 		}
 
 		return Page();

--- a/TASVideos/TagHelpers/WikiMarkupTagHelper.cs
+++ b/TASVideos/TagHelpers/WikiMarkupTagHelper.cs
@@ -21,7 +21,8 @@ public partial class WikiMarkup(IViewComponentHelper viewComponentHelper) : TagH
 		((IViewContextAware)viewComponentHelper).Contextualize(ViewContext);
 		output.TagName = "article";
 		output.AddCssClass("wiki");
-		await Util.RenderHtmlAsync(Markup ?? "", new TagHelperTextWriter(output.Content), this);
+		Console.WriteLine($"===== in WikiMarkup, PageData is {(PageData is null ? "null" : "not null")} and PageData.PageName is {PageData?.PageName ?? "(null)"}");
+		await Util.RenderHtmlAsync(Markup ?? "", new TagHelperTextWriter(output.Content), this, allowMoreStyling: PageData?.PageName is null/*editor preview*/ or SystemWiki.NavbarMain or SystemWiki.NavbarWikiTop);
 	}
 
 	bool IWriterHelper.CheckCondition(string condition)


### PR DESCRIPTION
edit 2026-07-25: rebased w/o changes, waiting for design to be finalised

will resolve #2359

Test by writing
```
%%DIV nav-item dropdown
%%DIV dropdown-menu show
[=SandBox|=%%NAV_ITEM.svg|title=SandBox]
[=RecentChanges|=%%NAV_ITEM.svg|title=Recent Changes]
[=WikiOrphans|=%%NAV_ITEM.svg|title=Orphans]
[=TODO|=%%NAV_ITEM.svg|title=To Do]
[=System|=%%NAV_ITEM.svg|title=System Pages]
%%DIV_END
%%DIV_END
```
into the `NavbarWikiTop` system page.