### PR TITLE
Add support for Console Timing method

### DIFF
--- a/TASVideos.Data/Entity/OptimizationMetric.cs
+++ b/TASVideos.Data/Entity/OptimizationMetric.cs
@@ -15,8 +15,12 @@ public enum OptimizationMetric
 
 	[Display(Name = "Maximum Score")]
 	HighScore,
+
 	[Display(Name = "Minimum Score")]
 	LowScore,
+
+	[Display(Name = "Console Timing")]
+	ConsoleTiming
 }
 
 public static class OptimizationMetricExtensions
@@ -26,7 +30,8 @@ public static class OptimizationMetricExtensions
 		public bool IsTime() =>
 			metric is OptimizationMetric.TASTiming
 				or OptimizationMetric.RTATiming
-				or OptimizationMetric.InGameTiming;
+				or OptimizationMetric.InGameTiming
+				or OptimizationMetric.ConsoleTiming;
 
 		public bool IsScore() =>
 			metric is OptimizationMetric.HighScore
@@ -47,6 +52,10 @@ public static class OptimizationMetricExtensions
 			else if (metric == OptimizationMetric.InGameTiming)
 			{
 				return "(IGT)";
+			}
+			else if (metric == OptimizationMetric.ConsoleTiming)
+			{
+				return "(Console Timing)";
 			}
 
 			return "";

--- a/tests/TASVideos.Data.Tests/Entity/PublicationTests.cs
+++ b/tests/TASVideos.Data.Tests/Entity/PublicationTests.cs
@@ -306,6 +306,7 @@ public class PublicationTests
 	[TestMethod]
 	[DataRow(OptimizationMetric.InGameTiming, "21:23.330", "PC Celeste by  in 21:23.330 (IGT)")]
 	[DataRow(OptimizationMetric.RTATiming, "59:27.31", "PC Celeste by  in 59:27.31 (RTA)")]
+	[DataRow(OptimizationMetric.ConsoleTiming, "59:27.31", "PC Celeste by  in 59:27.31 (Console Timing)")]
 	public void GenerateTitle_TimeOptimizationMetrics_ShowsTimeOverride(OptimizationMetric metric, string metricValue, string expectedTitle)
 	{
 		var publication = new Publication

--- a/tests/TASVideos.Data.Tests/Entity/SubmissionTests.cs
+++ b/tests/TASVideos.Data.Tests/Entity/SubmissionTests.cs
@@ -307,6 +307,7 @@ public class SubmissionTests
 	[TestMethod]
 	[DataRow(OptimizationMetric.InGameTiming, "21:23.330", "#1111: 's PC Celeste in 21:23.330 (IGT)")]
 	[DataRow(OptimizationMetric.RTATiming, "59:27.31", "#1111: 's PC Celeste in 59:27.31 (RTA)")]
+	[DataRow(OptimizationMetric.ConsoleTiming, "59:27.31", "#1111: 's PC Celeste in 59:27.31 (Console Timing)")]
 	public void GenerateTitle_TimeOptimizationMetrics_ShowsTimeOverride(OptimizationMetric metric, string metricValue, string expectedTitle)
 	{
 		var submission = new Submission


### PR DESCRIPTION
Expands options in Optimization Metric to support Console Timing. This has been explicitly requested to handle Super Mario 64 120 Stars, as the SM64 Community prefers using timing measured on a Nintendo 64 and optimizes accordingly (down to camera manipulation for lag reduction being a major factor of the movie).

Here are a couple pictures of the option working on my local environment. Publication and Submission entity tests have been updated accordingly.

<img width="1316" height="594" alt="image" src="https://github.com/user-attachments/assets/6072a54e-392a-48da-bddb-387393de8ea9" />
<img width="306" height="144" alt="image" src="https://github.com/user-attachments/assets/e46f15ec-6ef4-4465-8e72-05e6d82bd1fb" />
