### PR TITLE
Fix DisplayMiniMovie exceptions on empty movie sets

### DIFF
--- a/TASVideos/WikiModules/DisplayMiniMovie.cshtml.cs
+++ b/TASVideos/WikiModules/DisplayMiniMovie.cshtml.cs
@@ -25,11 +25,9 @@ public class DisplayMiniMovie(ApplicationDbContext db) : WikiViewComponent
 			.Select(p => p.Id)
 			.ToListAsync();
 
-		var id = candidateIds.ToList().AtRandom();
-
-		// id == 0 means there are no publications, which is an out-of-the-box problem only
-		if (id != 0)
+		if (candidateIds.Count > 0)
 		{
+			var id = candidateIds.AtRandom();
 			Movie = await db.Publications
 				.ToMiniMovieModel()
 				.SingleAsync(p => p.Id == id);


### PR DESCRIPTION
Found in the logs, it throws exceptions when the list of movies to be displayed is empty. This can happen e.g. when trying to show movies from a flag or class that doesn't exist (anymore).